### PR TITLE
Fix Mash issue with underscore suffix

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/AbcSize:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 209
+  Max: 212
 
 # Offense count: 8
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ scheme are considered to be bugs.
 * [#436](https://github.com/intridea/hashie/pull/436): Ensure that `Hashie::Extensions::IndifferentAccess` injects itself after a non-destructive merge - [@michaelherold](https://github.com/michaelherold).
 * [#437](https://github.com/intridea/hashie/pull/437): Allow codependent properties to be set on Dash - [@michaelherold](https://github.com/michaelherold).
 * [#438](https://github.com/intridea/hashie/pull/438): Fix: `NameError (uninitialized constant Hashie::Extensions::Parsers::YamlErbParser::Pathname)` in `Hashie::Mash.load` - [@onk](https://github.com/onk).
+* [#442](https://github.com/intridea/hashie/pull/442): Mash log warning / error with hash key suffix - [@zserafini](https://github.com/zserafini).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -248,13 +248,13 @@ module Hashie
       self
     end
 
-    def respond_to_missing?(method_name, *args)
+    def respond_to_missing?(method_name, *args, ignore_suffix: false)
       return true if key?(method_name)
       suffix = method_suffix(method_name)
-      if suffix
+      if suffix && !ignore_suffix
         true
       else
-        super
+        super(method_name, args)
       end
     end
 
@@ -350,7 +350,7 @@ module Hashie
     end
 
     def log_collision?(method_key)
-      respond_to?(method_key) && !self.class.disable_warnings? &&
+      respond_to?(method_key, ignore_suffix: true) && !self.class.disable_warnings? &&
         !(regular_key?(method_key) || regular_key?(method_key.to_s))
     end
   end

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -248,13 +248,13 @@ module Hashie
       self
     end
 
-    def respond_to_missing?(method_name, *args, ignore_suffix: false)
+    def respond_to_missing?(method_name, *args)
       return true if key?(method_name)
       suffix = method_suffix(method_name)
-      if suffix && !ignore_suffix
+      if suffix && !@ignore_suffix
         true
       else
-        super(method_name, args)
+        super
       end
     end
 
@@ -350,8 +350,11 @@ module Hashie
     end
 
     def log_collision?(method_key)
-      respond_to?(method_key, ignore_suffix: true) && !self.class.disable_warnings? &&
+      @ignore_suffix = true
+      respond_to?(method_key) && !self.class.disable_warnings? &&
         !(regular_key?(method_key) || regular_key?(method_key.to_s))
+    ensure
+      @ignore_suffix = false
     end
   end
 end

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -503,6 +503,13 @@ describe Hashie::Mash do
       expect(converted.to_hash['a'].first.is_a?(Hash)).to be_truthy
       expect(converted.to_hash['a'].first['c'].first.is_a?(Hashie::Mash)).to be_falsy
     end
+
+    it 'allows use of suffix in hash keys' do
+      initial_hash = { "#{SecureRandom.hex}_" => 'a' }
+      expect_any_instance_of(Hashie::Mash).to_not receive(:log_built_in_message)
+      mash = Hashie::Mash.new(initial_hash)
+      expect(mash[initial_hash.first.first]).to eq('a')
+    end
   end
 
   describe '#fetch' do

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -504,11 +504,10 @@ describe Hashie::Mash do
       expect(converted.to_hash['a'].first['c'].first.is_a?(Hashie::Mash)).to be_falsy
     end
 
-    it 'allows use of suffix in hash keys' do
+    it 'allows use of suffix in hash keys without logging a warning' do
       initial_hash = { "#{SecureRandom.hex}_" => 'a' }
       expect_any_instance_of(Hashie::Mash).to_not receive(:log_built_in_message)
       mash = Hashie::Mash.new(initial_hash)
-      expect(mash[initial_hash.first.first]).to eq('a')
     end
   end
 


### PR DESCRIPTION
This fixes an issue I noticed in Ruby 2.2.2 where initializing a Hashie:Mash with a hash that includes a key with an accepted suffix, like " _ ", raises a NameError (```NameError: undefined method 'foo_' for class 'Hashie::Mash'```)

In newer Ruby versions, including 2.2.9, the issue only results in an erroneous warning about name collision from https://github.com/intridea/hashie/blob/4c880a8a10611baae6e95376492428202242b6de/lib/hashie/mash.rb#L339

However, in 2.2.2 the result is worse since https://github.com/intridea/hashie/blob/4c880a8a10611baae6e95376492428202242b6de/lib/hashie/mash.rb#L342 causes an error due to ```method(method_key)``` not being defined.


Note: The expected behavior can be seen Hashie v3.4.4