### PR TITLE
Update the gemspec for improved information and installation size/speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ scheme are considered to be bugs.
 
 ### Miscellaneous
 
+* [#981](https://github.com/hashie/hashie/pull/981): Exclude tests from the gem release to reduce installation size and improve installation speed - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ## [4.0.0] - 2019-10-30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,19 @@ git pull upstream master
 git checkout -b my-feature-branch
 ```
 
-#### Bundle Install and Test
+#### Install dependencies
+
+You can use the setup script to install dependencies for the gem and its integration tests.
+
+```
+bin/setup
+```
+
+#### Test
 
 Ensure that you can build the project and run tests.
 
 ```
-bundle install
 bundle exec rake
 ```
 

--- a/Gemfile
+++ b/Gemfile
@@ -10,20 +10,25 @@ group :development do
   gem 'pry'
   gem 'pry-stack_explorer', platforms: %i[ruby_19 ruby_20 ruby_21]
   gem 'rubocop', '0.52.1'
+
+  group :test do
+    # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
+    # rubocop:disable Bundler/DuplicatedGem
+    require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
+    if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+       Hashie::Extensions::RubyVersion.new('2.4.0')
+      gem 'activesupport', '~> 5.x', require: false
+    else
+      gem 'activesupport', '~> 4.x', require: false
+    end
+    # rubocop:enable Bundler/DuplicatedGem
+    gem 'rake'
+    gem 'rspec', '~> 3'
+    gem 'rspec-pending_for', '~> 0.1'
+  end
 end
 
 group :test do
-  # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
-  # rubocop:disable Bundler/DuplicatedGem
-  require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
-  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
-     Hashie::Extensions::RubyVersion.new('2.4.0')
-    gem 'activesupport', '~> 5.x', require: false
-  else
-    gem 'activesupport', '~> 4.x', require: false
-  end
-  # rubocop:enable Bundler/DuplicatedGem
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
   gem 'danger-changelog', '~> 0.1.0', require: false
-  gem 'rspec-core', '~> 3.1.7'
 end

--- a/bin/setup
+++ b/bin/setup
@@ -1,7 +1,12 @@
 #!/bin/bash
+
 set -euo pipefail
 IFS=$'\n\t'
 
 bundle install
 
-# Do any other automated setup that you need to do here
+for dir in spec/integration/*; do
+  pushd "$dir"
+  bundle install
+  popd
+done

--- a/hashie.gemspec
+++ b/hashie.gemspec
@@ -17,6 +17,15 @@ Gem::Specification.new do |gem|
   gem.files += Dir['spec/**/*.rb']
   gem.test_files = Dir['spec/**/*.rb']
 
+  if gem.respond_to?(:metadata)
+    gem.metadata = {
+      'bug_tracker_uri'   => 'https://github.com/hashie/hashie/issues',
+      'changelog_uri'     => 'https://github.com/hashie/hashie/blob/master/CHANGELOG.md',
+      'documentation_uri' => 'https://www.rubydoc.info/gems/hashie',
+      'source_code_uri'   => 'https://github.com/hashie/hashie'
+    }
+  end
+
   gem.add_development_dependency 'rake', '< 11'
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rspec-pending_for', '~> 0.1'

--- a/hashie.gemspec
+++ b/hashie.gemspec
@@ -24,7 +24,5 @@ Gem::Specification.new do |gem|
     }
   end
 
-  gem.add_development_dependency 'rake', '< 11'
-  gem.add_development_dependency 'rspec', '~> 3.0'
-  gem.add_development_dependency 'rspec-pending_for', '~> 0.1'
+  gem.add_development_dependency 'bundler'
 end

--- a/hashie.gemspec
+++ b/hashie.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |gem|
   gem.files = %w[.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE README.md UPGRADING.md]
   gem.files += %w[Rakefile hashie.gemspec]
   gem.files += Dir['lib/**/*.rb']
-  gem.files += Dir['spec/**/*.rb']
-  gem.test_files = Dir['spec/**/*.rb']
 
   if gem.respond_to?(:metadata)
     gem.metadata = {


### PR DESCRIPTION
## Metadata additions

RubyGems.org has recently added the capability to have extra metadata
URLs shown on the gem page. These are handy for people who are new to a
gem or need to report an issue.

## Tests in the gem

When you're installing a gem in a production environment, you want it to
install as fast it can. One of the ways you can speed up the
installation of the gem is by making it smaller. We currently ship the
test suite with the gem, increasing the size of the built gem
significantly.

By not shipping the test suite, we can shrink the size of the gem by
38%. Below are the measurements I took for that statement.

**The size of the gem with the test suite**

    $ du -b hashie-4.0.1.gem
    80384	hashie-4.0.1.gem

**The size of the gem without the test suite**

    $ du -b hashie-4.0.1.gem
    50176	hashie-4.0.1.gem

## Bundler as a development dependency

Our contributing documentation specifically mentions Bundler so we
should set it as a development dependency.