### PR TITLE
Ensure that Hashie::Arrays are not deconverted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ scheme are considered to be bugs.
 ### Fixed
 
 * [#467](https://github.com/intridea/hashie/pull/467): Fixed `DeepMerge#deep_merge` mutating nested values within the receiver - [@michaelherold](https://github.com/michaelherold).
+* [#505](https://github.com/hashie/hashie/pull/505): Ensure that `Hashie::Array`s are not deconverted within `Hashie::Mash`es to make `Mash#dig` work properly - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -382,8 +382,6 @@ module Hashie
       when ::Hash
         val = val.dup if duping
         self.class.new(val)
-      when Array
-        val.map { |e| convert_value(e) }
       when ::Array
         Array.new(val.map { |e| convert_value(e) })
       else

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -982,6 +982,7 @@ describe Hashie::Mash do
   with_minimum_ruby('2.3.0') do
     describe '#dig' do
       subject { described_class.new(a: { b: 1 }) }
+
       it 'accepts both string and symbol as key' do
         expect(subject.dig(:a, :b)).to eq(1)
         expect(subject.dig('a', 'b')).to eq(1)
@@ -992,6 +993,14 @@ describe Hashie::Mash do
         it 'accepts a numeric value as key' do
           expect(subject.dig(1, :b)).to eq(1)
           expect(subject.dig('1', :b)).to eq(1)
+        end
+      end
+
+      context 'when the Mash wraps a Hashie::Array' do
+        it 'handles digging into an array' do
+          mash = described_class.new(alphabet: { first_three: Hashie::Array['a', 'b', 'c'] })
+
+          expect(mash.dig(:alphabet, :first_three, 0)).to eq 'a'
         end
       end
     end


### PR DESCRIPTION
In order for `#dig` to work properly, we need Arrays to be
`Hashie::Array`s to be aware of the key conversion. Our original
`Mash#convert_value` method was deconverting `Hashie::Array`s into
normal Arrays and causing `#dig` to behave in an unexpected manner.

Fixes #504