### PR TITLE
Suppress `Psych.safe_load` arg warn when using Psych 3.1.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ scheme are considered to be bugs.
 
 * [#467](https://github.com/intridea/hashie/pull/467): Fixed `DeepMerge#deep_merge` mutating nested values within the receiver - [@michaelherold](https://github.com/michaelherold).
 * [#505](https://github.com/hashie/hashie/pull/505): Ensure that `Hashie::Array`s are not deconverted within `Hashie::Mash`es to make `Mash#dig` work properly - [@michaelherold](https://github.com/michaelherold).
+* [#507](https://github.com/hashie/hashie/pull/507): Suppress `Psych.safe_load` arg warn when using Psych 3.1.0+ - [@koic](https://github.com/koic).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/extensions/parsers/yaml_erb_parser.rb
+++ b/lib/hashie/extensions/parsers/yaml_erb_parser.rb
@@ -18,12 +18,29 @@ module Hashie
           permitted_classes = @options.fetch(:permitted_classes) { [] }
           permitted_symbols = @options.fetch(:permitted_symbols) { [] }
           aliases = @options.fetch(:aliases) { true }
-          # TODO: Psych in newer rubies expects these args to be keyword args.
-          YAML.safe_load template.result, permitted_classes, permitted_symbols, aliases
+
+          yaml_safe_load(template, permitted_classes, permitted_symbols, aliases)
         end
 
         def self.perform(file_path, options = {})
           new(file_path, options).perform
+        end
+
+        private
+
+        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('3.1.0') # Ruby 2.6+
+          def yaml_safe_load(template, permitted_classes, permitted_symbols, aliases)
+            YAML.safe_load(
+              template.result,
+              permitted_classes: permitted_classes,
+              permitted_symbols: permitted_symbols,
+              aliases: aliases
+            )
+          end
+        else
+          def yaml_safe_load(template, permitted_classes, permitted_symbols, aliases)
+            YAML.safe_load(template.result, permitted_classes, permitted_symbols, aliases)
+          end
         end
       end
     end


### PR DESCRIPTION
This PR suppresses the following `Psych.safe_load` args warn when using Psych 3.1.0 (Ruby 2.6+).

```console
% bundle exec rake spec
(snip)

/Users/koic/src/github.com/intridea/hashie/lib/hashie/extensions/parsers/yaml_erb_parser.rb:22:
Passing permitted_classes with the 2nd argument of Psych.safe_load is
deprecated. Use keyword argument like Psych.safe_load(yaml,
permitted_classes: ...) instead.
/Users/koic/src/github.com/intridea/hashie/lib/hashie/extensions/parsers/yaml_erb_parser.rb:22:
Passing permitted_symbols with the 3rd argument of Psych.safe_load is
deprecated. Use keyword argument like Psych.safe_load(yaml,
permitted_symbols: ...) instead.
/Users/koic/src/github.com/intridea/hashie/lib/hashie/extensions/parsers/yaml_erb_parser.rb:22:
Passing aliases with the 4th argument of Psych.safe_load is
deprecated. Use keyword argument like Psych.safe_load(yaml, aliases:
...) instead
```