### PR TITLE
Only define compact on ruby >= 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ scheme are considered to be bugs.
 * [#467](https://github.com/intridea/hashie/pull/467): Fixed `DeepMerge#deep_merge` mutating nested values within the receiver - [@michaelherold](https://github.com/michaelherold).
 * [#505](https://github.com/hashie/hashie/pull/505): Ensure that `Hashie::Array`s are not deconverted within `Hashie::Mash`es to make `Mash#dig` work properly - [@michaelherold](https://github.com/michaelherold).
 * [#507](https://github.com/hashie/hashie/pull/507): Suppress `Psych.safe_load` arg warn when using Psych 3.1.0+ - [@koic](https://github.com/koic).
+* [#510](https://github.com/hashie/hashie/pull/510): Ensure that `Hashie::Mash#compact` is only defined on Ruby version >= 2.4.0 - [@bobbymcwho](https://github.com/bobbymcwho).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -173,12 +173,6 @@ module Hashie
       super(*keys.map { |key| convert_key(key) })
     end
 
-    # Returns a new instance of the class it was called on, with nil values
-    # removed.
-    def compact
-      self.class.new(super)
-    end
-
     # Returns a new instance of the class it was called on, using its keys as
     # values, and its values as keys. The new values and keys will always be
     # strings.
@@ -339,6 +333,12 @@ module Hashie
     with_minimum_ruby('2.4.0') do
       def transform_values(&blk)
         self.class.new(super(&blk))
+      end
+
+      # Returns a new instance of the class it was called on, with nil values
+      # removed.
+      def compact
+        self.class.new(super)
       end
     end
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -882,27 +882,6 @@ describe Hashie::Mash do
     end
   end
 
-  describe '#compact' do
-    subject(:mash) { described_class.new(a: 1, b: nil) }
-
-    it 'returns a Hashie::Mash' do
-      expect(mash.compact).to be_kind_of(described_class)
-    end
-
-    it 'removes keys with nil values' do
-      expect(mash.compact).to eq('a' => 1)
-    end
-
-    context 'when using with subclass' do
-      let(:subclass) { Class.new(Hashie::Mash) }
-      subject(:sub_mash) { subclass.new(a: 1, b: nil) }
-
-      it 'creates an instance of subclass' do
-        expect(sub_mash.compact).to be_kind_of(subclass)
-      end
-    end
-  end
-
   describe '#invert' do
     subject(:mash) { described_class.new(a: 'apple', b: 4) }
 
@@ -1024,6 +1003,27 @@ describe Hashie::Mash do
 
         it 'creates an instance of subclass' do
           expect(sub_mash).to be_kind_of(subclass)
+        end
+      end
+    end
+
+    describe '#compact' do
+      subject(:mash) { described_class.new(a: 1, b: nil) }
+
+      it 'returns a Hashie::Mash' do
+        expect(mash.compact).to be_kind_of(described_class)
+      end
+
+      it 'removes keys with nil values' do
+        expect(mash.compact).to eq('a' => 1)
+      end
+
+      context 'when using with subclass' do
+        let(:subclass) { Class.new(Hashie::Mash) }
+        subject(:sub_mash) { subclass.new(a: 1, b: nil) }
+
+        it 'creates an instance of subclass' do
+          expect(sub_mash.compact).to be_kind_of(subclass)
         end
       end
     end


### PR DESCRIPTION
Another issue I came across while working on #508. It wasn't caught before because we included activesupport in the test suite and therefore `#compact` was monkey patched in. 