### PR TITLE
Suppress keyword arguments warning for Ruby 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ scheme are considered to be bugs.
 * [#508](https://github.com/hashie/hashie/pull/508): Fixed `Mash.load` no longer uses Rails-only `#except` - [@bobbymcwho](https://github.com/bobbymcwho).
 * [#508](https://github.com/hashie/hashie/pull/508): Fixed `Hashie::Extensions::DeepMerge` `#deep_merge` not correctly dup'ing sub-hashes if active_support hash extensions were not present - [@bobbymcwho](https://github.com/bobbymcwho).
 * [#510](https://github.com/hashie/hashie/pull/510): Ensure that `Hashie::Mash#compact` is only defined on Ruby version >= 2.4.0 - [@bobbymcwho](https://github.com/bobbymcwho).
+* [#511](https://github.com/hashie/hashie/pull/511): Suppress keyword arguments warning for Ruby 2.7.0 - [@koic](https://github.com/koic).
 * Your contribution here.
 
 ### Security

--- a/spec/hashie/extensions/mash/symbolize_keys_spec.rb
+++ b/spec/hashie/extensions/mash/symbolize_keys_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hashie::Extensions::Mash::SymbolizeKeys do
     end
     let(:instance) { my_mash.new('outer' => { 'inner' => 42 }, 'testing' => [1, 2, 3]) }
 
-    subject { destructure.call(instance) }
+    subject { destructure.call(**instance) }
 
     it 'is converted on method calls' do
       expect(subject).to eq(outer: { inner: 42 }, testing: [1, 2, 3])


### PR DESCRIPTION
This PR suppresses the following keyword arguments warning for Ruby 2.7.0.

```console
% bundle exec rspec spec/hashie/extensions/mash/symbolize_keys_spec.rb
(snip)

/Users/koic/src/github.com/hahie/hashie/spec/hashie/extensions/mash/symbolize_keys_spec.rb:29:
warning: Using the last argument as keyword parameters is
deprecated; maybe ** should be added to the call
/Users/koic/src/github.com/hahie/hashie/spec/hashie/extensions/mash/symbolize_keys_spec.rb:21:
warning: The called method `call' is defined here
```

For Ruby 2.8.0-dev (Ruby 3.0) the warning will be `ArgumentError`.
ruby/ruby#2794