### PR TITLE
Suppress an integer unification warning for Ruby 2.4.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ scheme are considered to be bugs.
 * [#500](https://github.com/hashie/hashie/pull/500): Do not warn when setting Mash keys that look like underbang, bang, and query methods - [@michaelherold](https://github.com/michaelherold).
 * [#510](https://github.com/hashie/hashie/pull/510): Ensure that `Hashie::Mash#compact` is only defined on Ruby version >= 2.4.0 - [@bobbymcwho](https://github.com/bobbymcwho).
 * [#511](https://github.com/hashie/hashie/pull/511): Suppress keyword arguments warning for Ruby 2.7.0 - [@koic](https://github.com/koic).
+* [#512](https://github.com/hashie/hashie/pull/512): Suppress an integer unification warning for using Ruby 2.4.0+ - [@koic](https://github.com/koic).
 * Your contribution here.
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ class DataModelHash < Hashie::Dash
 end
 
 model = DataModelHash.new(id: '123', created: '2014-04-25 22:35:28')
-model.id.class          #=> Fixnum
+model.id.class          #=> Integer (Fixnum if you are using Ruby 2.3 or lower)
 model.created_at.class  #=> Time
 ```
 
@@ -966,7 +966,7 @@ this will produce the following
 
 ```ruby
 result = Result.new(id: '123', creation_date: '2012-03-30 17:23:28')
-result.id.class         # => Fixnum
+result.id.class         # => Integer (Fixnum if you are using Ruby 2.3 or lower)
 result.created_at.class # => Time
 ```
 

--- a/lib/hashie/extensions/dash/property_translation.rb
+++ b/lib/hashie/extensions/dash/property_translation.rb
@@ -35,7 +35,7 @@ module Hashie
       #   end
       #
       #   model = DataModelHash.new(id: '123', created: '2014-04-25 22:35:28')
-      #   model.id.class          #=> Fixnum
+      #   model.id.class          #=> Integer (Fixnum if you are using Ruby 2.3 or lower)
       #   model.created_at.class  #=> Time
       module PropertyTranslation
         def self.included(base)

--- a/lib/hashie/utils.rb
+++ b/lib/hashie/utils.rb
@@ -34,10 +34,10 @@ module Hashie
     # @return [Array<Class>]
     def self.integer_classes
       @integer_classes ||=
-        if const_defined?(:Fixnum)
-          [Fixnum, Bignum] # rubocop:disable Lint/UnifiedInteger
-        else
+        if 0.class == Integer
           [Integer]
+        else
+          [Fixnum, Bignum] # rubocop:disable Lint/UnifiedInteger
         end
     end
   end


### PR DESCRIPTION
This PR suppresss the following integer unification warning for using Ruby 2.4.0+

```console
% ruby -v
ruby 2.4.9p362 (2019-10-02 revision 67824) [x86_64-darwin17]
% bundle exec rspec spec/hashie/extensions/deep_merge_spec.rb

Hashie::Extensions::DeepMerge
/Users/koic/src/github.com/hahie/hashie/lib/hashie/utils.rb:38: warning:
constant ::Fixnum is deprecated
/Users/koic/src/github.com/hahie/hashie/lib/hashie/utils.rb:38: warning:
constant ::Bignum is deprecated
```

This PR makes the following change to the product code:

```diff
diff --git a/lib/hashie/utils.rb b/lib/hashie/utils.rb
index 5b55b9a..a1365f8 100644
--- a/lib/hashie/utils.rb
+++ b/lib/hashie/utils.rb
@@ -21,24 +21,11 @@ module Hashie
     # @return [Object] the duplicated value
     def self.safe_dup(value)
       case value
-      when Complex, FalseClass, NilClass, Rational, Method, Symbol, TrueClass, *integer_classes
+      when Complex, FalseClass, NilClass, Rational, Method, Symbol, TrueClass, Integer
         value
       else
         value.dup
       end
     end
-
-    # Lists the classes Ruby uses for integers
-    #
-    # @api private
-    # @return [Array<Class>]
-    def self.integer_classes
-      @integer_classes ||=
-        if const_defined?(:Fixnum)
-          [Fixnum, Bignum] # rubocop:disable Lint/UnifiedInteger
-        else
-          [Integer]
-        end
-    end
   end
 end
```

This change that uses `Integer` instead of `Fixnum` and `Bignum` in `case ... when` statement is compatible with Ruby 2.3 and lower.

```ruby
% ruby -v
ruby 2.3.8p459 (2018-10-18 revision 65136) [x86_64-darwin17]

42.class          #=> Fixnum
42.is_a?(Integer) #=> true

case 42
when Fixnum
  true
else
  false
end               #=> true

case 42
when Integer
  true
else
  false
end               #=> true
```

`Bignum` has the same behavior as `Fixnum` because it inherits `Integer`.