### PR TITLE
Suppress a Ruby's warning when using Ruby 2.6.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ scheme are considered to be bugs.
 * [#510](https://github.com/hashie/hashie/pull/510): Ensure that `Hashie::Mash#compact` is only defined on Ruby version >= 2.4.0 - [@bobbymcwho](https://github.com/bobbymcwho).
 * [#511](https://github.com/hashie/hashie/pull/511): Suppress keyword arguments warning for Ruby 2.7.0 - [@koic](https://github.com/koic).
 * [#512](https://github.com/hashie/hashie/pull/512): Suppress an integer unification warning for using Ruby 2.4.0+ - [@koic](https://github.com/koic).
+* [#513](https://github.com/hashie/hashie/pull/513): Suppress a Ruby's warning when using Ruby 2.6.0+ - [@koic](https://github.com/koic).
 * Your contribution here.
 
 ### Security

--- a/lib/hashie/extensions/ruby_version_check.rb
+++ b/lib/hashie/extensions/ruby_version_check.rb
@@ -9,7 +9,11 @@ module Hashie
 
       module ClassMethods
         def with_minimum_ruby(version)
-          yield if RubyVersion.new(RUBY_VERSION) >= RubyVersion.new(version)
+          yield if with_minimum_ruby?(version)
+        end
+
+        def with_minimum_ruby?(version)
+          RubyVersion.new(RUBY_VERSION) >= RubyVersion.new(version)
         end
       end
     end

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -207,20 +207,7 @@ module Hashie
     alias include? key?
     alias member? key?
 
-    # Performs a deep_update on a duplicate of the
-    # current mash.
-    def deep_merge(other_hash, &blk)
-      dup.deep_update(other_hash, &blk)
-    end
-
-    # Recursively merges this mash with the passed
-    # in hash, merging each hash in the hierarchy.
-    def deep_update(other_hash, &blk)
-      _deep_update(other_hash, &blk)
-      self
-    end
-
-    with_minimum_ruby('2.6.0') do
+    if with_minimum_ruby?('2.6.0')
       # Performs a deep_update on a duplicate of the
       # current mash.
       def deep_merge(*other_hashes, &blk)
@@ -233,6 +220,19 @@ module Hashie
         other_hashes.each do |other_hash|
           _deep_update(other_hash, &blk)
         end
+        self
+      end
+    else
+      # Performs a deep_update on a duplicate of the
+      # current mash.
+      def deep_merge(other_hash, &blk)
+        dup.deep_update(other_hash, &blk)
+      end
+
+      # Recursively merges this mash with the passed
+      # in hash, merging each hash in the hierarchy.
+      def deep_update(other_hash, &blk)
+        _deep_update(other_hash, &blk)
         self
       end
     end


### PR DESCRIPTION
This PR suppresses the following warning that `deep_merge` method and `deep_update` method are defined twice when using Ruby 2.6.0+.

```console
% bundle exec rake
(snip)

/Users/koic/src/github.com/hahie/hashie/lib/hashie/mash.rb:226: warning:
method redefined; discarding old deep_merge
/Users/koic/src/github.com/hahie/hashie/lib/hashie/mash.rb:212: warning:
previous definition of deep_merge was here
/Users/koic/src/github.com/hahie/hashie/lib/hashie/mash.rb:232: warning:
method redefined; discarding old deep_update
/Users/koic/src/github.com/hahie/hashie/lib/hashie/mash.rb:218: warning:
previous definition of deep_update was here
```