### PR TITLE
Elasticsearch integration spec fix

### DIFF
--- a/spec/integration/elasticsearch/integration_spec.rb
+++ b/spec/integration/elasticsearch/integration_spec.rb
@@ -23,7 +23,7 @@ end
 RSpec.describe 'elaasticsearch-model' do
   # See https://github.com/hashie/hashie/issues/354#issuecomment-363306114
   # for the reason why this doesn't work as you would expect
-  it 'raises an error when the model does not has an id' do
+  it 'raises an error when the model does not have an id' do
     object = MyModel.new
     stub_elasticsearch_client
 

--- a/spec/integration/elasticsearch/integration_spec.rb
+++ b/spec/integration/elasticsearch/integration_spec.rb
@@ -14,12 +14,16 @@ class MyModel < Hashie::Mash
 
   index_name 'model'
   document_type 'model'
+
+  def as_indexed_json(args)
+    { name: 'new' }
+  end
 end
 
 RSpec.describe 'elaasticsearch-model' do
   # See https://github.com/hashie/hashie/issues/354#issuecomment-363306114
   # for the reason why this doesn't work as you would expect
-  it 'raises an error when the model does has an id' do
+  it 'raises an error when the model does not has an id' do
     object = MyModel.new
     stub_elasticsearch_client
 

--- a/spec/integration/elasticsearch/integration_spec.rb
+++ b/spec/integration/elasticsearch/integration_spec.rb
@@ -15,8 +15,8 @@ class MyModel < Hashie::Mash
   index_name 'model'
   document_type 'model'
 
-  def as_indexed_json(options={})
-    { body: '{}' }
+  def as_indexed_json(options = {})
+    { body: '{}' }.merge(options)
   end
 end
 

--- a/spec/integration/elasticsearch/integration_spec.rb
+++ b/spec/integration/elasticsearch/integration_spec.rb
@@ -15,8 +15,8 @@ class MyModel < Hashie::Mash
   index_name 'model'
   document_type 'model'
 
-  def as_indexed_json(args)
-    { name: 'new' }
+  def as_indexed_json(options={})
+    { body: '{}' }
   end
 end
 


### PR DESCRIPTION
Here is the implementation of index_document in elasticseach-model gem,

```
def index_document(options={})
  document = as_indexed_json
  request = { index: index_name,
              id:    id,
              body:  document }
  request.merge!(type: document_type) if document_type
  client.index(request.merge!(options))
end 
```

This spec is failing because the as_indexed_json method returns nil, resulting in body key to nil, which should not be.

To fix this spec, I have implemented the as_indexed_json method in MyModel class, but I am not sure whether this is the correct way. 

pr #518

@dblock @michaelherold 