### PR TITLE
Added TOC and upgraded danger-changelog to verify the keep-a-changelog formatted CHANGELOG.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle; done
       script:
         - set -e ; for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle exec rspec $dir; done
-    - rvm: 2.6.3
+    - rvm: 2.6.6
       dist: bionic
     - rvm: rbx-3
       dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,19 @@
-# Change Log
+# Changelog
 
-All notable changes to this project will be documented in this file. This
-project adheres to [Semantic Versioning 2.0.0][semver]. Any violations of this
-scheme are considered to be bugs.
+All notable changes to this project will be documented in this file.
 
-[semver]: http://semver.org/spec/v2.0.0.html
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Any violations of this scheme are considered to be bugs.
 
-## [Unreleased][unreleased]
+## [Unreleased]
 
 [unreleased]: https://github.com/hashie/hashie/compare/v4.1.0...master
 
 ### Added
 
+* [#523](https://github.com/hashie/hashie/pull/523): Added TOC, ensure a keep-a-changelog formatted CHANGELOG - [@dblock](https://github.com/dblock).
+* [#522](https://github.com/hashie/hashie/pull/522): Added eierlegende Wollmilchsau mascot graphic - [@carolineartz](https://github.com/carolineartz).
 * Your contribution here.
 
 ### Changed
@@ -36,11 +38,6 @@ scheme are considered to be bugs.
 
 * Your contribution here.
 
-### Miscellaneous
-
-* [#522](https://github.com/hashie/hashie/pull/522): Added eierlegende Wollmilchsau mascot graphic - [@carolineartz](https://github.com/carolineartz).
-* Your contribution here.
-
 ## [4.1.0] - 2020-02-01
 
 [4.1.0]: https://github.com/hashie/hashie/compare/v4.0.0...v4.1.0
@@ -48,6 +45,10 @@ scheme are considered to be bugs.
 ### Added
 
 * [#499](https://github.com/hashie/hashie/pull/499): Add `Hashie::Extensions::Mash::PermissiveRespondTo` to make specific subclasses of Mash fully respond to messages for use with `SimpleDelegator` - [@michaelherold](https://github.com/michaelherold).
+
+### Changed
+
+* [#498](https://github.com/hashie/hashie/pull/498): Exclude tests from the gem release to reduce installation size and improve installation speed - [@michaelherold](https://github.com/michaelherold).
 
 ### Fixed
 
@@ -61,10 +62,6 @@ scheme are considered to be bugs.
 * [#511](https://github.com/hashie/hashie/pull/511): Suppress keyword arguments warning for Ruby 2.7.0 - [@koic](https://github.com/koic).
 * [#512](https://github.com/hashie/hashie/pull/512): Suppress an integer unification warning for using Ruby 2.4.0+ - [@koic](https://github.com/koic).
 * [#513](https://github.com/hashie/hashie/pull/513): Suppress a Ruby's warning when using Ruby 2.6.0+ - [@koic](https://github.com/koic).
-
-### Miscellaneous
-
-* [#498](https://github.com/hashie/hashie/pull/498): Exclude tests from the gem release to reduce installation size and improve installation speed - [@michaelherold](https://github.com/michaelherold).
 
 ## [4.0.0] - 2019-10-30
 
@@ -81,6 +78,7 @@ scheme are considered to be bugs.
 ### Changed
 
 * [#481](https://github.com/hashie/hashie/pull/481): Implement non-destructive standard Hash methods - [@bobbymcwho](https://github.com/bobbymcwho).
+* [#482](https://github.com/hashie/hashie/pull/482): Update Travis configs to make jruby builds run on trusty dist - [@BobbyMcWho](https://github.com/BobbyMcWho).
 
 ### Fixed
 
@@ -88,11 +86,7 @@ scheme are considered to be bugs.
 * [#465](https://github.com/hashie/hashie/pull/465): Fixed `deep_update` to call any readers when a key exists - [@laertispappas](https://github.com/laertispappas).
 * [#479](https://github.com/hashie/hashie/pull/479): Fixed an issue with `Hash#except` not returning a `Mash` in Rails 6 - [@bobbymcwho](https://github.com/bobbymcwho).
 * [#489](https://github.com/hashie/hashie/pull/489): Updated the documentation to exlain the behavior of `Mash` and keyword arguments - [@Bhacaz](https://github.com/Bhacaz).
-
-### Miscellaneous
-
 * [#465](https://github.com/hashie/hashie/pull/465): Clean up our RuboCop configuration and fix the outstanding line length violations. This involved some minor refactoring on `Hashie::Extensions::Coercion`, `Hashie::Extensions::Dash::IndifferentAccess`, `Hashie::Extensions::DeepLocate`, `Hashie::Extensions::Mash::SafeAssignment`, and `Hashie::Hash`, but none that were detectable via the test suite - [@michaelherold](https://github.com/michaelherold).
-* [#482](https://github.com/hashie/hashie/pull/482): Update Travis configs to make jruby builds run on trusty dist. - [@BobbyMcWho](https://github.com/BobbyMcWho).
 
 ## [3.6.0] - 2018-08-13
 
@@ -101,6 +95,12 @@ scheme are considered to be bugs.
 ### Added
 
 * [#455](https://github.com/hashie/hashie/pull/455): Allow overriding methods when passing in a hash - [@lnestor](https://github.com/lnestor).
+* [#434](https://github.com/hashie/hashie/pull/434): Add documentation around Mash sub-Hashes - [@michaelherold](https://github.com/michaelherold).
+* [#439](https://github.com/hashie/hashie/pull/439): Add an integration spec for Elasticsearch - [@michaelherold](https://github.com/michaelherold).
+
+### Changed
+
+* [#433](https://github.com/hashie/hashie/pull/433): Update Rubocop to the most recent version - [@michaelherold](https://github.com/michaelherold).
 
 ### Fixed
 
@@ -110,21 +110,15 @@ scheme are considered to be bugs.
 * [#438](https://github.com/hashie/hashie/pull/438): Fix: `NameError (uninitialized constant Hashie::Extensions::Parsers::YamlErbParser::Pathname)` in `Hashie::Mash.load` - [@onk](https://github.com/onk).
 * [#457](https://github.com/hashie/hashie/pull/457): Fix `Trash` to allow it to copy properties from other properties - [@michaelherold](https://github.com/michaelherold).
 
-### Miscellaneous
-
-* [#433](https://github.com/hashie/hashie/pull/433): Update Rubocop to the most recent version - [@michaelherold](https://github.com/michaelherold).
-* [#434](https://github.com/hashie/hashie/pull/434): Add documentation around Mash sub-Hashes - [@michaelherold](https://github.com/michaelherold).
-* [#439](https://github.com/hashie/hashie/pull/439): Add an integration spec for Elasticsearch - [@michaelherold](https://github.com/michaelherold).
-
 ## [3.5.7] - 2017-12-19
 
 [3.5.7]: https://github.com/hashie/hashie/compare/v3.5.6...v3.5.7
 
 ### Fixed
 
-[#430](https://github.com/hashie/hashie/pull/430): Fix Hashie::Rash randomly losing items - [@Antti](https://github.com/Antti)
+* [#430](https://github.com/hashie/hashie/pull/430): Fix Hashie::Rash randomly losing items - [@Antti](https://github.com/Antti).
 
-### Miscellaneous
+### Changed
 
 * [#425](https://github.com/hashie/hashie/pull/425): Update rubies in CI - [@kachick](https://github.com/kachick).
 
@@ -132,7 +126,7 @@ scheme are considered to be bugs.
 
 [3.5.6]: https://github.com/hashie/hashie/compare/v3.5.5...v3.5.6
 
-### Miscellaneous
+### Fixed
 
 * [#416](https://github.com/hashie/hashie/pull/416): Fix `warning: instance variable @disable_warnings not initialized` - [@axfcampos](https://github.com/axfcampos).
 
@@ -179,15 +173,12 @@ scheme are considered to be bugs.
 
 * [#395](https://github.com/hashie/hashie/pull/395): Add the ability to disable warnings in Mash subclasses - [@michaelherold](https://github.com/michaelherold).
 * [#400](https://github.com/hashie/hashie/pull/400): Fix Hashie.logger load and set the Hashie logger to the Rails logger in a Rails environment - [@michaelherold](https://github.com/michaelherold).
+* [#397](https://github.com/hashie/hashie/pull/397): Add the integration specs harness into the main test tasks - [@michaelherold](https://github.com/michaelherold).
 
 ### Fixed
 
 * [#396](https://github.com/hashie/hashie/pull/396): Fix for specs in #381: Incorrect use of shared context meant example was not being run - [@biinari](https://github.com/biinari).
 * [#399](https://github.com/hashie/hashie/pull/399): Fix passing Pathname object to Hashie::Mesh.load() - [@albb0920](https://github.com/albb0920).
-
-### Miscellanous
-
-* [#397](https://github.com/hashie/hashie/pull/397): Add the integration specs harness into the main test tasks - [@michaelherold](https://github.com/michaelherold).
 
 ## [3.5.1] - 2017-01-31
 
@@ -217,10 +208,7 @@ scheme are considered to be bugs.
 * [#377](https://github.com/hashie/hashie/pull/377): Dont use Rubygems to check ruby version - [@sazor](https://github.com/sazor).
 * [#378](https://github.com/hashie/hashie/pull/378): Deep find all searches inside all nested hashes - [@sazor](https://github.com/sazor).
 * [#380](https://github.com/hashie/hashie/pull/380): Evaluate procs default values of Dash in object initialization - [@sazor](https://github.com/sazor).
-
-### Miscellanous
-
-* [#387](https://github.com/hashie/hashie/pull/387): Fix builds failing due to Rake 11 having a breaking change - [@michaelherold](https://github.com/michaelherold).
+* [#387](https://github.com/hashie/hashie/pull/387): Fixed builds failing due to Rake 11 having a breaking change - [@michaelherold](https://github.com/michaelherold).
 
 ## [3.4.6] - 2016-09-16
 
@@ -237,6 +225,7 @@ scheme are considered to be bugs.
 ### Added
 
 * [#337](https://github.com/hashie/hashie/pull/337), [#331](https://github.com/hashie/hashie/issues/331): `Hashie::Mash#load` accepts a `Pathname` object - [@gipcompany](https://github.com/gipcompany).
+* [#366](https://github.com/hashie/hashie/pull/366): Added Danger, PR linter - [@dblock](https://github.com/dblock).
 
 ### Deprecated
 
@@ -246,10 +235,6 @@ scheme are considered to be bugs.
 
 * [#358](https://github.com/hashie/hashie/pull/358): Fixed support for Array#dig - [@modosc](https://github.com/modosc).
 * [#365](https://github.com/hashie/hashie/pull/365): Ensured ActiveSupport::HashWithIndifferentAccess is defined before use in #deep_locate  - [@mikejarema](https://github.com/mikejarema).
-
-### Miscellanous
-
-* [#366](https://github.com/hashie/hashie/pull/366): Added Danger, PR linter - [@dblock](https://github.com/dblock).
 
 ## [3.4.4] - 2016-04-29
 
@@ -282,7 +267,7 @@ scheme are considered to be bugs.
 * [#304](https://github.com/hashie/hashie/pull/304): Ensured compatibility of `Hash` extensions with singleton objects - [@regexident](https://github.com/regexident).
 * [#310](https://github.com/hashie/hashie/pull/310): Fixed `Hashie::Extensions::SafeAssignment` bug with private methods - [@marshall-lee](https://github.com/marshall-lee).
 
-### Miscellaneous
+### Changed
 
 * [#313](https://github.com/hashie/hashie/pull/313): Restrict pending spec to only Ruby versions 2.2.0-2.2.2 - [@pboling](https://github.com/pboling).
 * [#315](https://github.com/hashie/hashie/pull/315): Default `bin/` scripts: `console` and `setup` - [@pboling](https://github.com/pboling).
@@ -417,8 +402,6 @@ scheme are considered to be bugs.
 
 [3.0.0]: https://github.com/hashie/hashie/compare/v2.1.2...v3.0.0
 
-Note: This version introduces several backward incompatible API changes. See [UPGRADING](UPGRADING.md) for details.
-
 ### Added
 
 * [#149](https://github.com/hashie/hashie/issues/149): Allow IgnoreUndeclared and DeepMerge to be used with undeclared properties - [@jhaesus](https://github.com/jhaesus).
@@ -463,6 +446,7 @@ Note: This version introduces several backward incompatible API changes. See [UP
 ### Changed
 
 * [#89](https://github.com/hashie/hashie/issues/89): Do not respond to every method with suffix in Hashie::Mash, fixes Rails strong_parameters - [@Maxim-Filimonov](https://github.com/Maxim-Filimonov).
+* Ruby style now enforced with Rubocop - [@dblock](https://github.com/dblock).
 
 ### Removed
 
@@ -484,10 +468,6 @@ Note: This version introduces several backward incompatible API changes. See [UP
 * [#130](https://github.com/hashie/hashie/pull/130): IndifferentAccess now works without MergeInitializer - [@npj](https://github.com/npj).
 * [#133](https://github.com/hashie/hashie/pull/133): Fixed Hash##to_hash with symbolize_keys - [@mhuggins](https://github.com/mhuggins).
 
-### Miscellaneous
-
-* Ruby style now enforced with Rubocop - [@dblock](https://github.com/dblock).
-
 ## [2.0.5] - 2013-05-10
 
 [2.0.5]: https://github.com/hashie/hashie/compare/v2.0.4...v2.0.5
@@ -504,7 +484,7 @@ Note: This version introduces several backward incompatible API changes. See [UP
 
 * [#94](https://github.com/hashie/hashie/pull/94): Made #fetch method consistent with normal Hash - [@markiz](https://github.com/markiz).
 
-### Miscellaneous
+### Changed
 
 * [#90](https://github.com/hashie/hashie/pull/90): Various doc tweaks - [@craiglittle](https://github.com/craiglittle).
 
@@ -532,10 +512,7 @@ Note: This version introduces several backward incompatible API changes. See [UP
 ### Removed
 
 * [#81](https://github.com/hashie/hashie/pull/81): Removed Mash#object_id override - [@matschaffer](https://github.com/matschaffer).
-
-### Miscellaneous
-
-* Gem cleanup: removed VERSION, Gemfile.lock - [@jch](https://github.com/jch), [@mbleigh](https://github.com/mbleigh).
+* Removed VERSION and Gemfile.lock - [@jch](https://github.com/jch), [@mbleigh](https://github.com/mbleigh).
 
 ## [2.0.0] - 2013-02-16
 
@@ -545,6 +522,7 @@ Note: This version introduces several backward incompatible API changes. See [UP
 
 * [#41](https://github.com/hashie/hashie/pull/41): DeepMerge extension - [@nashby](https://github.com/nashby).
 * [#78](https://github.com/hashie/hashie/pull/78): Merge and update accepts a block - [@jch](https://github.com/jch).
+* [#72](https://github.com/hashie/hashie/pull/72): Updated gemspec with license info - [@jordimassaguerpla](https://github.com/jordimassaguerpla).
 
 ### Changed
 
@@ -559,7 +537,3 @@ Note: This version introduces several backward incompatible API changes. See [UP
 * [#62](https://github.com/hashie/hashie/pull/62): Updated respond_to? method signature to match ruby core definition - [@dlupu](https://github.com/dlupu).
 * [#63](https://github.com/hashie/hashie/pull/63): Dash defaults are dup'ed before assigned - [@ohrite](https://github.com/ohrite).
 * [#66](https://github.com/hashie/hashie/pull/66): Mash#fetch works with symbol or string keys - [@arthwood](https://github.com/arthwood).
-
-### Miscellaneous
-
-* [#72](https://github.com/hashie/hashie/pull/72): Updated gemspec with license info - [@jordimassaguerpla](https://github.com/jordimassaguerpla).

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,6 @@
 # see http://danger.systems
 
-changelog.check
+changelog.format = :keep_a_changelog
+changelog.check!
+
+toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -31,5 +31,6 @@ end
 
 group :test do
   gem 'codeclimate-test-reporter', '~> 1.0', require: false
-  gem 'danger-changelog', '~> 0.1.0', require: false
+  gem 'danger-changelog', '~> 0.6.1', require: false
+  gem 'danger-toc', '~> 0.2.0', require: false
 end

--- a/README.md
+++ b/README.md
@@ -8,6 +8,49 @@
 
 [![eierlegende Wollmilchsau](./mascot.svg)](#mascot) Hashie is a growing collection of tools that extend Hashes and make them more useful.
 
+# Table of Contents
+
+- [Installation](#installation)
+- [Stable Release](#stable-release)
+- [Hash Extensions](#hash-extensions)
+- [Logging](#logging)
+  - [Coercion](#coercion)
+  - [Coercing Collections](#coercing-collections)
+  - [Coercing Hashes](#coercing-hashes)
+  - [Coercing Core Types](#coercing-core-types)
+  - [Coercion Proc](#coercion-proc)
+    - [A note on circular coercion](#a-note-on-circular-coercion)
+  - [KeyConversion](#keyconversion)
+  - [MergeInitializer](#mergeinitializer)
+  - [MethodAccess](#methodaccess)
+  - [MethodAccessWithOverride](#methodaccesswithoverride)
+  - [MethodOverridingInitializer](#methodoverridinginitializer)
+  - [IndifferentAccess](#indifferentaccess)
+  - [IgnoreUndeclared](#ignoreundeclared)
+  - [DeepMerge](#deepmerge)
+  - [DeepFetch](#deepfetch)
+  - [DeepFind](#deepfind)
+  - [DeepLocate](#deeplocate)
+- [StrictKeyAccess](#strictkeyaccess)
+- [Mash](#mash)
+  - [KeepOriginalKeys](#keeporiginalkeys)
+  - [PermissiveRespondTo](#permissiverespondto)
+  - [SafeAssignment](#safeassignment)
+  - [SymbolizeKeys](#symbolizekeys)
+  - [DefineAccessors](#defineaccessors)
+- [Dash](#dash)
+  - [Potential Gotchas](#potential-gotchas)
+  - [PropertyTranslation](#propertytranslation)
+  - [Mash and Rails 4 Strong Parameters](#mash-and-rails-4-strong-parameters)
+  - [Coercion](#coercion-1)
+- [Trash](#trash)
+- [Clash](#clash)
+- [Rash](#rash)
+  - [Auto-Optimized](#auto-optimized)
+- [Mascot](#mascot)
+- [Contributing](#contributing)
+- [Copyright](#copyright)
+
 ## Installation
 
 Hashie is available as a RubyGem:
@@ -270,8 +313,6 @@ This extension can be mixed in to your Hash subclass to allow you to use Strings
 
 In addition, IndifferentAccess will also inject itself into sub-hashes so they behave the same.
 
-Example:
-
 ```ruby
 class MyHash < Hash
   include Hashie::Extensions::MergeInitializer
@@ -446,8 +487,6 @@ books.deep_locate -> (key, value, object) { key == :pages && value <= 120 }
 
 This extension can be mixed in to allow a Hash to raise an error when attempting to extract a value using a non-existent key.
 
-### Example:
-
 ```ruby
 class StrictKeyAccessHash < Hash
   include Hashie::Extensions::StrictKeyAccess
@@ -464,8 +503,6 @@ end
 ## Mash
 
 Mash is an extended Hash that gives simple pseudo-object functionality that can be built from hashes and easily extended. It is intended to give the user easier access to the objects within the Mash through a property-like syntax, while still retaining all Hash functionality.
-
-### Example:
 
 ```ruby
 mash = Hashie::Mash.new
@@ -489,11 +526,9 @@ mash.inspect # => <Hashie::Mash>
 
 **Note:** The `?` method will return false if a key has been set to false or nil. In order to check if a key has been set at all, use the `mash.key?('some_key')` method instead.
 
-### How does Mash handle conflicts with pre-existing methods?
+_How does Mash handle conflicts with pre-existing methods?_
 
 Please note that a Mash will not override methods through the use of the property-like syntax. This can lead to confusion if you expect to be able to access a Mash value through the property-like syntax for a key that conflicts with a method name. However, it protects users of your library from the unexpected behavior of those methods being overridden behind the scenes.
-
-#### Example:
 
 ```ruby
 mash = Hashie::Mash.new
@@ -565,11 +600,9 @@ Hashie::Mash.quiet.new(zip: '90210', compact: true) # no errors logged
 Hashie::Mash.quiet(:zip).new(zip: '90210', compact: true) # error logged for compact
 ```
 
-### How does the wrapping of Mash sub-Hashes work?
+_How does the wrapping of Mash sub-Hashes work?_
 
 Mash duplicates any sub-Hashes that you add to it and wraps them in a Mash. This allows for infinite chaining of nested Hashes within a Mash without modifying the object(s) that are passed into the Mash. When you subclass Mash, the subclass wraps any sub-Hashes in its own class. This preserves any extensions that you mixed into the Mash subclass and allows them to work within the sub-Hashes, in addition to the main containing Mash.
-
-#### Example:
 
 ```ruby
 mash = Hashie::Mash.new(name: "Hashie", dependencies: { rake: "< 11", rspec: "~> 3.0" })
@@ -580,11 +613,9 @@ my_gem = MyGem.new(name: "Hashie", dependencies: { rake: "< 11", rspec: "~> 3.0"
 my_gem.dependencies.class #=> MyGem
 ```
 
-### How does Mash handle key types which cannot be symbolized?
+_How does Mash handle key types which cannot be symbolized?_
 
 Mash preserves keys which cannot be converted *directly* to both a string and a symbol, such as numeric keys. Since Mash is conceived to provide psuedo-object functionality, handling keys which cannot represent a method call falls outside its scope of value.
-
-#### Example
 
 ```ruby
 Hashie::Mash.new('1' => 'one string', :'1' => 'one sym', 1 => 'one num')
@@ -593,11 +624,9 @@ Hashie::Mash.new('1' => 'one string', :'1' => 'one sym', 1 => 'one num')
 
 The symbol key `:'1'` is converted the string `'1'` to support indifferent access and consequently its value `'one sym'` will override the previously set `'one string'`. However, the subsequent key of `1` cannot directly convert to a symbol and therefore **not** converted to the string `'1'` that would otherwise override the previously set value of `'one sym'`.
 
-### What else can Mash do?
+_What else can Mash do?_
 
 Mash allows you also to transform any files into a Mash objects.
-
-#### Example:
 
 ```yml
 #/etc/config/settings/twitter.yml
@@ -653,7 +682,7 @@ Specify `permitted_symbols`, `permitted_classes` and `aliases` options as needed
 Mash.load('data/user.csv', permitted_classes: [Symbol], permitted_symbols: [], aliases: false)
 ```
 
-### Mash Extension: KeepOriginalKeys
+### KeepOriginalKeys
 
 This extension can be mixed into a Mash to keep the form of any keys passed directly into the Mash. By default, Mash converts symbol keys to strings to give indifferent access. This extension still allows indifferent access, but keeps the form of the keys to eliminate confusion when you're not expecting the keys to change.
 
@@ -672,7 +701,7 @@ mash['string_key']  #=> 'string'
 mash[:string_key]  #=> 'string'
 ```
 
-### Mash Extension: PermissiveRespondTo
+### PermissiveRespondTo
 
 By default, Mash only states that it responds to built-in methods, affixed methods (e.g. setters, underbangs, etc.), and keys that it currently contains. That means it won't state that it responds to a getter for an unset key, as in the following example:
 
@@ -696,11 +725,9 @@ mash.respond_to? :b  #=> true
 
 This comes at the cost of approximately 20% performance for initialization and setters and 19KB of permanent memory growth for each such class that you create.
 
-### Mash Extension: SafeAssignment
+### SafeAssignment
 
 This extension can be mixed into a Mash to guard the attempted overwriting of methods by property setters. When mixed in, the Mash will raise an `ArgumentError` if you attempt to write a property with the same name as an existing method.
-
-#### Example:
 
 ```ruby
 class SafeMash < ::Hashie::Mash
@@ -712,7 +739,7 @@ safe_mash.zip   = 'Test' # => ArgumentError
 safe_mash[:zip] = 'test' # => still ArgumentError
 ```
 
-### Mash Extension: SymbolizeKeys
+### SymbolizeKeys
 
 This extension can be mixed into a Mash to change the default behavior of converting keys to strings. After mixing this extension into a Mash, the Mash will convert all string keys to symbols. It can be useful to use with keywords argument, which required symbol keys.
 
@@ -745,7 +772,7 @@ end
 
 However, on Rubies less than 2.0, this means that every key you send to the Mash will generate a symbol. Since symbols are not garbage-collected on older versions of Ruby, this can cause a slow memory leak when using a symbolized Mash with data generated from user input.
 
-### Mash Extension: DefineAccessors
+### DefineAccessors
 
 This extension can be mixed into a Mash so it makes it behave like `OpenStruct`. It reduces the overhead of `method_missing?` magic by lazily defining field accessors when they're requested.
 
@@ -775,8 +802,6 @@ mash = ::Hashie::Mash.new.with_accessors!
 Dash is an extended Hash that has a discrete set of defined properties and only those properties may be set on the hash. Additionally, you can set defaults for each property. You can also flag a property as required. Required properties will raise an exception if unset. Another option is message for required properties, which allow you to add custom messages for required property.
 
 You can also conditionally require certain properties by passing a Proc or Symbol. If a Proc is provided, it will be run in the context of the Dash instance. If a Symbol is provided, the value returned for the property or method of the same name will be evaluated. The property will be required if the result of the conditional is truthy.
-
-### Example:
 
 ```ruby
 class Person < Hashie::Dash
@@ -814,8 +839,6 @@ p.occupation   # => 'Rubyist'
 
 Properties defined as symbols are not the same thing as properties defined as strings.
 
-### Example:
-
 ```ruby
 class Tricky < Hashie::Dash
   property :trick
@@ -839,7 +862,7 @@ p = Tricky.new('trick' => 'two')
 p.trick # => NoMethodError
 ```
 
-### Potential gotchas
+### Potential Gotchas
 
 Because Dashes are subclasses of the built-in Ruby Hash class, the double-splat operator takes the Dash as-is without any conversion. This can lead to strange behavior when you use the double-splat operator on a Dash as the first part of a keyword list or built Hash. For example:
 
@@ -871,12 +894,10 @@ qux.is_a?(Hash)                #=> true
 qux[:quux]                     #=> "corge"
 ```
 
-### Dash Extension: PropertyTranslation
+### PropertyTranslation
 
 The `Hashie::Extensions::Dash::PropertyTranslation` mixin extends a Dash with
 the ability to remap keys from a source hash.
-
-### Example from inconsistent APIs
 
 Property translation is useful when you need to read data from another
 application -- such as a Java API -- where the keys are named differently from
@@ -896,8 +917,6 @@ person = PersonHash.new(firstName: 'Michael', l_name: 'Bleigh')
 person[:first_name]  #=> 'Michael'
 person[:last_name]   #=> 'Bleigh
 ```
-
-### Example using translation lambdas
 
 You can also use a lambda to translate the value. This is particularly useful
 when you want to ensure the type of data you're wrapping.
@@ -919,7 +938,7 @@ model.created_at.class  #=> Time
 
 To enable compatibility with Rails 4 use the [hashie-forbidden_attributes](https://github.com/Maxim-Filimonov/hashie-forbidden_attributes) gem.
 
-### Dash Extension: Coercion.
+### Coercion
 
 If you want to use `Hashie::Extensions::Coercion` together with `Dash` then
 you may probably want to use `Hashie::Extensions::Dash::Coercion` instead.
@@ -990,8 +1009,6 @@ Clash is a Chainable Lazy Hash that allows you to easily construct complex hashe
 
 Essentially, a Clash is a generalized way to provide much of the same kind of "chainability" that libraries like Arel or Rails 2.x's named_scopes provide.
 
-### Example:
-
 ```ruby
 c = Hashie::Clash.new
 c.where(abc: 'def').order(:created_at)
@@ -1017,8 +1034,6 @@ A good use case for the Rash is an URL router for a web framework, where URLs ne
 
 If the Rash's value is a `proc`, the `proc` will be automatically called with the regexp's MatchData (matched groups) as a block argument.
 
-### Example:
-
 ```ruby
 
 # Mapping names to appropriate greetings
@@ -1035,7 +1050,7 @@ mapper["I like traffic lights"] # => "Who DOESN'T like traffic lights?!"
 mapper["Get off my lawn!"]      # => "Forget your lawn, old man!"
 ```
 
-### Auto-optimized
+### Auto-Optimized
 
 **Note:** The Rash is automatically optimized every 500 accesses (which means that it sorts the list of Regexps, putting the most frequently matched ones at the beginning).
 


### PR DESCRIPTION
Added TOC and upgraded danger-changelog to verify the keep-a-changelog formatted CHANGELOG. Note that the "Miscellaneous" section is not a thing in that format and that I had to fix https://github.com/dblock/danger-changelog/pull/58.  