### PR TITLE
Test with Ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
   - jruby-9.2.11.1
   - jruby-9.0.5.0
   - jruby-head
+  - truffleruby
 
 matrix:
   include:
@@ -28,10 +29,7 @@ matrix:
         - for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle; done
       script:
         - set -e ; for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle exec rspec $dir; done
-    - rvm: rbx-3
-      dist: trusty
-      bundler_args: --retry 0
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: rbx-3
+    - rvm: truffleruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ rvm:
   - truffleruby
 
 matrix:
+  fast_finish: true
   include:
     - rvm: 2.7
       name: "Run Danger and Code Climate"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ rvm:
 
 matrix:
   include:
-    - rvm: 2.5
+    - rvm: 2.7
       name: "Run Danger and Code Climate"
       before_script:
         - bundle exec danger
       after_script:
         - bundle exec codeclimate-test-reporter
-    - rvm: 2.5
+    - rvm: 2.7
       name: "Integration Tests"
       install:
         - for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ rvm:
   - 2.2
   - 2.1
   - ruby-head
+  - jruby-9.2.11.1
+  - jruby-head
 
 matrix:
   include:
@@ -29,8 +31,6 @@ matrix:
       dist: trusty
       bundler_args: --retry 0
     - rvm: jruby-9.0.5.0
-      dist: trusty
-    - rvm: jruby-head
       dist: trusty
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.1
   - ruby-head
   - jruby-9.2.11.1
+  - jruby-9.0.5.0
   - jruby-head
 
 matrix:
@@ -30,8 +31,6 @@ matrix:
     - rvm: rbx-3
       dist: trusty
       bundler_args: --retry 0
-    - rvm: jruby-9.0.5.0
-      dist: trusty
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,30 @@
 language: ruby
-sudo: false
 cache: bundler
 
 rvm:
-  - 2.5.3
-  - 2.4.5
-  - 2.3.8
-  - 2.2.9
-  - 2.1.10
+  - 2.7
+  - 2.6
+  - 2.5
+  - 2.4
+  - 2.3
+  - 2.2
+  - 2.1
   - ruby-head
 
 matrix:
   include:
-    - rvm: 2.5.3
+    - rvm: 2.5
       name: "Run Danger and Code Climate"
       before_script:
         - bundle exec danger
       after_script:
         - bundle exec codeclimate-test-reporter
-    - rvm: 2.5.3
+    - rvm: 2.5
       name: "Integration Tests"
       install:
         - for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle; done
       script:
         - set -e ; for dir in spec/integration/*; do BUNDLE_GEMFILE=$dir/Gemfile bundle exec rspec $dir; done
-    - rvm: 2.6.6
-      dist: bionic
     - rvm: rbx-3
       dist: trusty
       bundler_args: --retry 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Any violations of this scheme are considered to be bugs.
 ### Changed
 
 * [#521](https://github.com/hashie/hashie/pull/499): Do not convert keys that cannot be represented as symbols to `String` in `Mash` initialization - [@carolineartz](https://github.com/carolineartz).
+* [#524](https://github.com/hashie/hashie/pull/524): Test with Ruby 2.7 - [@aried3r](https://github.com/aried3r).
 * Your contribution here.
 
 ### Deprecated


### PR DESCRIPTION
`sudo: false` is deprecated.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration