### PR TITLE
Hashie::Extensions::Grep

### DIFF
--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -26,6 +26,7 @@ module Hashie
     autoload :DeepFetch,          'hashie/extensions/deep_fetch'
     autoload :DeepFind,           'hashie/extensions/deep_find'
     autoload :DeepLocate,         'hashie/extensions/deep_locate'
+    autoload :Grep,               'hashie/extensions/grep'
     autoload :PrettyInspect,      'hashie/extensions/pretty_inspect'
     autoload :KeyConversion,      'hashie/extensions/key_conversion'
     autoload :MethodAccessWithOverride, 'hashie/extensions/method_access'

--- a/lib/hashie/extensions/grep.rb
+++ b/lib/hashie/extensions/grep.rb
@@ -31,8 +31,16 @@ module Hashie
 
       private
 
+      def match_value?(pattern, value)
+        return false unless (value.class == String || value.class == Symbol)
+
+        !pattern.match(value).nil?
+      end
+
       def _grep(pattern, object = self, matches = [])
-        grep_result = DeepLocate.deep_locate -> (key, value, object) { !pattern.match(key).nil? }, object
+        grep_result = DeepLocate.deep_locate -> (key, value, object) { 
+          match_value?(pattern, key) || match_value?(pattern, value)
+        }, object
 
         matches.concat(grep_result)
       end

--- a/lib/hashie/extensions/grep.rb
+++ b/lib/hashie/extensions/grep.rb
@@ -31,15 +31,15 @@ module Hashie
 
       private
 
-      def match_value?(pattern, value)
-        return false unless (value.instance_of?(String) || value.instance_of?(Symbol))
+      def _match_text?(pattern, text)
+        return false unless (text.instance_of?(String) || text.instance_of?(Symbol))
 
-        !pattern.match(value).nil?
+        !pattern.match(text).nil?
       end
 
       def _grep(pattern, object = self, matches = [])
         grep_result = DeepLocate.deep_locate -> (key, value, object) { 
-          match_value?(pattern, key) || match_value?(pattern, value)
+          _match_text?(pattern, key) || _match_text?(pattern, value)
         }, object
 
         matches.concat(grep_result)

--- a/lib/hashie/extensions/grep.rb
+++ b/lib/hashie/extensions/grep.rb
@@ -1,0 +1,41 @@
+require 'hashie/extensions/deep_locate'
+module Hashie
+  module Extensions
+    module Grep
+      # Performs a depth-first search on deeply nested data structures for
+      # a key and returns all occurrences of the key.
+      #
+      #  options = {
+      #    users: [
+      #      { location: {address: '123 Street'} },
+      #      { location: {address: '234 Street'}}
+      #    ]
+      #  }
+      #  options.extend(Hashie::Extensions::Grep)
+      #  options.grep(/Street/) # => [{address: '123 Street'}, {address: '234 Street'}]
+      #
+      #  class MyHash < Hash
+      #    include Hashie::Extensions::Grep
+      #  end
+      #
+      #  my_hash = MyHash.new
+      #  my_hash[:users] = [
+      #    {location: {address: '123 Street'}},
+      #    {location: {address: '234 Street'}}
+      #  ]
+      #  my_hash.grep(/Street/) # => [{address: '123 Street'}, {address: '234 Street'}]
+      def grep(pattern)
+        matches = _grep(pattern)
+        matches.empty? ? nil : matches
+      end
+
+      private
+
+      def _grep(pattern, object = self, matches = [])
+        grep_result = DeepLocate.deep_locate -> (key, value, object) { !pattern.match(key).nil? }, object
+
+        matches.concat(grep_result)
+      end
+    end
+  end
+end

--- a/lib/hashie/extensions/grep.rb
+++ b/lib/hashie/extensions/grep.rb
@@ -32,7 +32,7 @@ module Hashie
       private
 
       def match_value?(pattern, value)
-        return false unless (value.class == String || value.class == Symbol)
+        return false unless (value.instance_of?(String) || value.instance_of?(Symbol))
 
         !pattern.match(value).nil?
       end

--- a/lib/hashie/extensions/grep.rb
+++ b/lib/hashie/extensions/grep.rb
@@ -12,7 +12,7 @@ module Hashie
       #    ]
       #  }
       #  options.extend(Hashie::Extensions::Grep)
-      #  options.grep(/Street/) # => [{address: '123 Street'}, {address: '234 Street'}]
+      #  options.grep(/Street/) # => [{:address: '123 Street'}, {:address: '234 Street'}]
       #
       #  class MyHash < Hash
       #    include Hashie::Extensions::Grep
@@ -23,7 +23,7 @@ module Hashie
       #    {location: {address: '123 Street'}},
       #    {location: {address: '234 Street'}}
       #  ]
-      #  my_hash.grep(/Street/) # => [{address: '123 Street'}, {address: '234 Street'}]
+      #  my_hash.grep(/Street/) # => [{:address: '123 Street'}, {:address: '234 Street'}]
       def grep(pattern)
         matches = _grep(pattern)
         matches.empty? ? nil : matches

--- a/spec/hashie/extensions/grep_spec.rb
+++ b/spec/hashie/extensions/grep_spec.rb
@@ -9,6 +9,7 @@ describe Hashie::Extensions::Grep do
           { title: 'Call of the Wild' },
           { title: 'Moby Dick' }
         ],
+        authors: [ 'Herman Melville', 'Jack London' ],
         shelves: nil,
         location: {
           address: '123 Library St.',
@@ -24,85 +25,16 @@ describe Hashie::Extensions::Grep do
       expect(instance.grep(/^t/)).to eq([{:title=>"Call of the Wild"}, {:title=>"Moby Dick"}, {:address=>"123 Library St.", :title=>"Main Library"}])
     end
 
-    # it 'detects a value from a nested array' do
-    #   expect(instance.deep_find(:title)).to eq('Call of the Wild')
-    # end
+    it 'greps a value from a nested hash' do
+      expect(instance.grep(/^M/)).to eq([{:title=>"Moby Dick"}, {:address=>"123 Library St.", :title=>"Main Library"}])
+    end
 
-    # it 'returns nil if it does not find a match' do
-    #   expect(instance.deep_find(:wahoo)).to be_nil
-    # end
+    it 'greps from an array' do
+      expect(instance.grep(/Jack/)).to eq([[ 'Herman Melville', 'Jack London' ]])
+    end
+
+    it 'returns nil if it does not find a match' do
+      expect(instance.grep(/wahoo/)).to be_nil
+    end
   end
-
-  # describe '#deep_find_all' do
-  #   it 'detects all values from a nested hash' do
-  #     expect(instance.deep_find_all(:title))
-  #       .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
-  #   end
-
-  #   it 'returns nil if it does not find any matches' do
-  #     expect(instance.deep_find_all(:wahoo)).to be_nil
-  #   end
-
-  #   context 'when match value is hash itself' do
-  #     let(:hash) do
-  #       {
-  #         title: {
-  #           type: :string
-  #         },
-  #         library: {
-  #           books: [
-  #             { title: 'Call of the Wild' },
-  #             { title: 'Moby Dick' }
-  #           ],
-  #           shelves: nil,
-  #           location: {
-  #             address: '123 Library St.',
-  #             title: 'Main Library'
-  #           }
-  #         }
-  #       }
-  #     end
-
-  #     it 'detects all values from a nested hash' do
-  #       expect(instance.deep_find_all(:title))
-  #         .to eq([{ type: :string }, 'Call of the Wild', 'Moby Dick', 'Main Library'])
-  #     end
-  #   end
-  # end
-
-  # context 'on a Hash including Hashie::Extensions::IndifferentAccess' do
-  #   let(:klass) { Class.new(Hash) { include Hashie::Extensions::IndifferentAccess } }
-  #   subject(:instance) { klass[hash.dup].extend(Hashie::Extensions::DeepFind) }
-
-  #   describe '#deep_find' do
-  #     it 'indifferently detects a value from a nested hash' do
-  #       expect(instance.deep_find(:address)).to eq('123 Library St.')
-  #       expect(instance.deep_find('address')).to eq('123 Library St.')
-  #     end
-
-  #     it 'indifferently detects a value from a nested array' do
-  #       expect(instance.deep_find(:title)).to eq('Call of the Wild')
-  #       expect(instance.deep_find('title')).to eq('Call of the Wild')
-  #     end
-
-  #     it 'indifferently returns nil if it does not find a match' do
-  #       expect(instance.deep_find(:wahoo)).to be_nil
-  #       expect(instance.deep_find('wahoo')).to be_nil
-  #     end
-  #   end
-
-  #   describe '#deep_find_all' do
-  #     it 'indifferently detects all values from a nested hash' do
-  #       expect(instance.deep_find_all(:title))
-  #         .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
-  #       expect(instance.deep_find_all('title'))
-  #         .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
-  #     end
-
-  #     it 'indifferently returns nil if it does not find any matches' do
-  #       expect(instance.deep_find_all(:wahoo)).to be_nil
-  #       expect(instance.deep_find_all('wahoo')).to be_nil
-  #     end
-  #   end
-  # end
 end

--- a/spec/hashie/extensions/grep_spec.rb
+++ b/spec/hashie/extensions/grep_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+describe Hashie::Extensions::Grep do
+  subject { Class.new(Hash) { include Hashie::Extensions::Grep } }
+  let(:hash) do
+    {
+      library: {
+        books: [
+          { title: 'Call of the Wild' },
+          { title: 'Moby Dick' }
+        ],
+        shelves: nil,
+        location: {
+          address: '123 Library St.',
+          title: 'Main Library'
+        }
+      }
+    }
+  end
+  let(:instance) { subject.new.update(hash) }
+
+  describe '#grep' do
+    it 'greps a key from a nested hash' do
+      expect(instance.grep(/^t/)).to eq([{:title=>"Call of the Wild"}, {:title=>"Moby Dick"}, {:address=>"123 Library St.", :title=>"Main Library"}])
+    end
+
+    # it 'detects a value from a nested array' do
+    #   expect(instance.deep_find(:title)).to eq('Call of the Wild')
+    # end
+
+    # it 'returns nil if it does not find a match' do
+    #   expect(instance.deep_find(:wahoo)).to be_nil
+    # end
+  end
+
+  # describe '#deep_find_all' do
+  #   it 'detects all values from a nested hash' do
+  #     expect(instance.deep_find_all(:title))
+  #       .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+  #   end
+
+  #   it 'returns nil if it does not find any matches' do
+  #     expect(instance.deep_find_all(:wahoo)).to be_nil
+  #   end
+
+  #   context 'when match value is hash itself' do
+  #     let(:hash) do
+  #       {
+  #         title: {
+  #           type: :string
+  #         },
+  #         library: {
+  #           books: [
+  #             { title: 'Call of the Wild' },
+  #             { title: 'Moby Dick' }
+  #           ],
+  #           shelves: nil,
+  #           location: {
+  #             address: '123 Library St.',
+  #             title: 'Main Library'
+  #           }
+  #         }
+  #       }
+  #     end
+
+  #     it 'detects all values from a nested hash' do
+  #       expect(instance.deep_find_all(:title))
+  #         .to eq([{ type: :string }, 'Call of the Wild', 'Moby Dick', 'Main Library'])
+  #     end
+  #   end
+  # end
+
+  # context 'on a Hash including Hashie::Extensions::IndifferentAccess' do
+  #   let(:klass) { Class.new(Hash) { include Hashie::Extensions::IndifferentAccess } }
+  #   subject(:instance) { klass[hash.dup].extend(Hashie::Extensions::DeepFind) }
+
+  #   describe '#deep_find' do
+  #     it 'indifferently detects a value from a nested hash' do
+  #       expect(instance.deep_find(:address)).to eq('123 Library St.')
+  #       expect(instance.deep_find('address')).to eq('123 Library St.')
+  #     end
+
+  #     it 'indifferently detects a value from a nested array' do
+  #       expect(instance.deep_find(:title)).to eq('Call of the Wild')
+  #       expect(instance.deep_find('title')).to eq('Call of the Wild')
+  #     end
+
+  #     it 'indifferently returns nil if it does not find a match' do
+  #       expect(instance.deep_find(:wahoo)).to be_nil
+  #       expect(instance.deep_find('wahoo')).to be_nil
+  #     end
+  #   end
+
+  #   describe '#deep_find_all' do
+  #     it 'indifferently detects all values from a nested hash' do
+  #       expect(instance.deep_find_all(:title))
+  #         .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+  #       expect(instance.deep_find_all('title'))
+  #         .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
+  #     end
+
+  #     it 'indifferently returns nil if it does not find any matches' do
+  #       expect(instance.deep_find_all(:wahoo)).to be_nil
+  #       expect(instance.deep_find_all('wahoo')).to be_nil
+  #     end
+  #   end
+  # end
+end


### PR DESCRIPTION
Grep on keys or values on a hash.

```
 options = {
   users: [
     { location: {address: '123 Street'} },
     { location: {address: '234 Street'}}
   ]
 }
 options.extend(Hashie::Extensions::Grep)
 options.grep(/Street/) # => [{:address: '123 Street'}, {:address: '234 Street'}]
```