### PR TITLE
Export all Dash properties with their defaults, even when not set internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Any violations of this scheme are considered to be bugs.
 * [#516](https://github.com/hashie/hashie/issues/516): Fixed `NoMethodError` raised when including `Hashie::Extensions::Mash::SymbolizeKeys` and `Hashie::Extensions::SymbolizeKeys` in mashes/hashes with non string or symbol keys - [@carolineartz](https://github.com/carolineartz).
 * [#531](https://github.com/hashie/hashie/pull/531): Fixed [slice doesn't work using symbols](https://github.com/hashie/hashie/issues/529) using hash with `IndifferentAccess` extension - [@gnomex](https://github.com/gnomex).
 * [#533](https://github.com/hashie/hashie/pull/533): Fixed `NoMethodError: undefined method `to_json'` at `hashie/dash_spec` - [@gnomex](https://github.com/gnomex).
+* [#535](https://github.com/hashie/hashie/pull/535): Restored the exporting of all properties as part of `Dash#to_h` and `Dash#to_hash` - [@michaelherold](https://github.com/michaelherold).
 * [#537](https://github.com/hashie/hashie/pull/537): Fixed inconsistencies with handling defaults in `Dash` with and without `IgnoreUnclared` mixed in - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 

--- a/lib/hashie/dash.rb
+++ b/lib/hashie/dash.rb
@@ -156,6 +156,13 @@ module Hashie
       self
     end
 
+    def to_h
+      defaults = ::Hash[self.class.properties.map { |prop| [prop, self.class.defaults[prop]] }]
+
+      defaults.merge(self)
+    end
+    alias to_hash to_h
+
     def update_attributes!(attributes)
       update_attributes(attributes)
 

--- a/lib/hashie/extensions/dash/indifferent_access.rb
+++ b/lib/hashie/extensions/dash/indifferent_access.rb
@@ -19,6 +19,15 @@ module Hashie
         end
         private_class_method :requires_class_methods?
 
+        def to_h
+          defaults = ::Hash[self.class.properties.map do |prop|
+            [Hashie::Extensions::IndifferentAccess.convert_key(prop), self.class.defaults[prop]]
+          end]
+
+          defaults.merge(self)
+        end
+        alias to_hash to_h
+
         module ClassMethods
           # Check to see if the specified property has already been
           # defined.

--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -25,6 +25,11 @@ module Hashie
     module IndifferentAccess
       include Hashie::Extensions::RubyVersionCheck
 
+      # @api private
+      def self.convert_key(key)
+        key.to_s
+      end
+
       def self.included(base)
         Hashie::Extensions::Dash::IndifferentAccess.maybe_extend(base)
 
@@ -68,7 +73,7 @@ module Hashie
       end
 
       def convert_key(key)
-        key.to_s
+        IndifferentAccess.convert_key(key)
       end
 
       # Iterates through the keys and values, reconverting them to

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -344,7 +344,7 @@ describe DashTest do
     before { subject.replace(first_name: 'Cain') }
 
     it 'return self' do
-      expect(subject.replace(email: 'bar').to_hash).to eq(email: 'bar', count: 0)
+      expect(subject.replace(email: 'bar').object_id).to eq subject.object_id
     end
 
     it 'sets all specified keys to their corresponding values' do

--- a/spec/hashie/dash_spec.rb
+++ b/spec/hashie/dash_spec.rb
@@ -416,6 +416,7 @@ describe DashTest do
         Class.new(Hashie::Dash) do
           property :a, required: -> { b.nil? }, message: 'is required if b is not set.'
           property :b, required: -> { a.nil? }, message: 'is required if a is not set.'
+          property :c, default: -> { 'c' }
         end
       end
 
@@ -433,6 +434,44 @@ describe DashTest do
 
       it 'raises an error when neither property is set' do
         expect { codependent.new(a: nil, b: nil) }.to raise_error(ArgumentError)
+      end
+
+      context 'exporting nil values' do
+        describe '#to_h' do
+          it 'does not prune nil values' do
+            expect(codependent.new(a: 'hi', b: nil).to_h).to eq(a: 'hi', b: nil, c: 'c')
+            expect(codependent.new(a: 'hi', b: nil, c: nil).to_hash).to eq(a: 'hi', b: nil, c: 'c')
+            expect(codependent.new(a: 'hi', b: nil).merge(c: nil).to_h).to(
+              eq(a: 'hi', b: nil, c: nil)
+            )
+          end
+        end
+
+        describe '#to_hash' do
+          it 'does not prune nil values' do
+            expect(codependent.new(a: 'hi', b: nil).to_hash).to eq(a: 'hi', b: nil, c: 'c')
+            expect(codependent.new(a: 'hi', b: nil, c: nil).to_hash).to eq(a: 'hi', b: nil, c: 'c')
+            expect(codependent.new(a: 'hi', b: nil).merge(c: nil).to_hash).to(
+              eq(a: 'hi', b: nil, c: nil)
+            )
+          end
+        end
+
+        describe '**' do
+          # Note: This test is an implementation detail of MRI and may not hold for
+          # other Ruby interpreters. But it's important to note in the test suite
+          # because it can be surprising for people unfamiliar with the semantics of
+          # double-splatting.
+          #
+          # For more information, see [this link][1]:
+          #
+          # [1]: https://github.com/hashie/hashie/issues/353#issuecomment-363294886
+          it 'prunes nil values because they are not set in the dash' do
+            dash = codependent.new(a: 'hi', b: nil)
+
+            expect(**dash).to eq(a: 'hi', c: 'c')
+          end
+        end
       end
     end
   end
@@ -481,6 +520,43 @@ describe Hashie::Dash, 'inheritance' do
     @bottom.property :echo, default: nil
     expect(@bottom.new).to have_key(:echo)
     expect(@bottom.new).to_not have_key('echo')
+  end
+
+  context 'exporting nil values' do
+    let(:test) do
+      Class.new(Hashie::Dash) do
+        property :foo
+        property :bar
+      end
+    end
+
+    describe '#to_h' do
+      it 'does not prune nil values' do
+        expect(test.new(foo: 'hi', bar: nil).to_h).to eq(foo: 'hi', bar: nil)
+      end
+    end
+
+    describe '#to_hash' do
+      it 'does not prune nil values' do
+        expect(test.new(foo: 'hi', bar: nil).to_hash).to eq(foo: 'hi', bar: nil)
+      end
+    end
+
+    describe '**' do
+      # Note: This test is an implementation detail of MRI and may not hold for
+      # other Ruby interpreters. But it's important to note in the test suite
+      # because it can be surprising for people unfamiliar with the semantics of
+      # double-splatting.
+      #
+      # For more information, see [this link][1]:
+      #
+      # [1]: https://github.com/hashie/hashie/issues/353#issuecomment-363294886
+      it 'prunes nil values because they are not set in the dash' do
+        dash = test.new(foo: 'hi', bar: nil)
+
+        expect(**dash).to eq(foo: 'hi')
+      end
+    end
   end
 end
 


### PR DESCRIPTION
In #437, we added the ability to have nilable codependent attributes. However, this change introduced a regression where those codependent attributes are no longer exported because they are not stored internally.

This change adds exporting for all Dash properties, whether they are set or not. The behavior uses the default value as the export for a key that was missing during initialization. If you set the value to `nil` later, it will be `nil` in the export.

Note that there is behavior in here that is related to an implementation detail of MRI (and currently JRuby) as noted in the last commit and in the comment above two example groups in the specs. I wanted to explicitly document it because it's not commonly known behavior.

Lastly, this includes a small refactor of how `IndifferentAccess` converts keys. This made it cleaner to be consistent with `Dash::IndifferentAccess` and gives us a singular place for us to handle converting things for indifferent access.

Closes #469 