### PR TITLE
Drop testing for JRuby 9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ rvm:
   - 2.1
   - ruby-head
   - jruby-9.2.11.1
-  - jruby-9.0.5.0
   - jruby-head
   - truffleruby
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Removed
 
+* [#538](https://github.com/hashie/hashie/pull/538): Dropped testing for JRuby 9.0, though not support - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 
 ### Fixed


### PR DESCRIPTION
Support for Ruby 2.4 was [dropped in April of this year][1], with other
versions earlier than that.

Per the [JRuby security policy][2], JRuby 9.2 is supported, but 9.0 is
not any longer.

JRuby 9.0 has been flaky on builds, so it's now causing a maintenance
burden.

This isn't a declaration that we won't support these versions, but I
don't think it makes sense to test on them any more. In the next major
release, I would like to define a support policy.

[1]: https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/
[2]: https://github.com/jruby/jruby/blob/4fd5e619f9d1f36d7bbca8f0013bb55e4ad57e8f/SECURITY.md