### PR TITLE
Run 2.7 tests once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.7
   - 2.6
   - 2.5
   - 2.4
@@ -19,7 +18,7 @@ matrix:
   fast_finish: true
   include:
     - rvm: 2.7
-      name: "Run Danger and Code Climate"
+      name: "Ruby: 2.7 (with Danger and Code Climate)"
       before_script:
         - bundle exec danger
       after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.1
   - ruby-head
   - jruby-9.2.11.1
-  - jruby-9.0.5.0
   - jruby-head
   - truffleruby
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Any violations of this scheme are considered to be bugs.
 * [#522](https://github.com/hashie/hashie/pull/522): Added eierlegende Wollmilchsau mascot graphic - [@carolineartz](https://github.com/carolineartz).
 * [#530](https://github.com/hashie/hashie/pull/530): Added Hashie::Extensions::Dash::PredefinedValues - [@caalberts](https://github.com/caalberts).
 * [#536](https://github.com/hashie/hashie/pull/536): Added exporting a normal Hash from an indifferent one through the `#to_hash` method - [@michaelherold](https://github.com/michaelherold).
-* [#539](https://github.com/hashie/hashie/pull/539): Run 2.7 tests once - [@anakinj](https://github.com/anakinj)
+* [#539](https://github.com/hashie/hashie/pull/539): Run 2.7 tests once - [@anakinj](https://github.com/anakinj).
 * Your contribution here.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Any violations of this scheme are considered to be bugs.
 * [#522](https://github.com/hashie/hashie/pull/522): Added eierlegende Wollmilchsau mascot graphic - [@carolineartz](https://github.com/carolineartz).
 * [#530](https://github.com/hashie/hashie/pull/530): Added Hashie::Extensions::Dash::PredefinedValues - [@caalberts](https://github.com/caalberts).
 * [#536](https://github.com/hashie/hashie/pull/536): Added exporting a normal Hash from an indifferent one through the `#to_hash` method - [@michaelherold](https://github.com/michaelherold).
+* [#539](https://github.com/hashie/hashie/pull/539): Run 2.7 tests once - [@anakinj](https://github.com/anakinj)
 * Your contribution here.
 
 ### Changed


### PR DESCRIPTION
Was using this projects Travis CI configuration as a reference on how one could execute the CodeClimate job and noticed that the tests for Ruby 2.7 were executed twice.

This change leaves the responsibility for testing 2.7 to the Danger+CodeClimate job.