### PR TITLE
No need to include Hashie::Extensions::PrettyInspect into Hashie::Mash

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -62,7 +62,6 @@ module Hashie
   #   mash.author # => <Mash>
   #
   class Mash < Hash
-    include Hashie::Extensions::PrettyInspect
     include Hashie::Extensions::RubyVersionCheck
     extend Hashie::Extensions::KeyConflictWarning
 


### PR DESCRIPTION
Because `Hashie::Mash`'s parent class `Hashie::Hash` already includes this very module `Hashie::Extensions::PrettyInspect`. https://github.com/hashie/hashie/blob/75410a6/lib/hashie/hash.rb#L9