### PR TITLE
enhance _deep_update

### DIFF
--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -244,7 +244,7 @@ module Hashie
     def _deep_update(other_hash, &blk)
       other_hash.each_pair do |k, v|
         key = convert_key(k)
-        if v.is_a?(::Hash) && key?(key) && regular_reader(key).is_a?(Mash)
+        if defined?(v.is_a?) && v.is_a?(::Hash) && key?(key) && regular_reader(key).is_a?(Mash)
           custom_reader(key).deep_update(v, &blk)
         else
           value = convert_value(v, true)

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -292,6 +292,12 @@ describe Hashie::Mash do
         expect(subject.details.city).to eq 'Imagineton'
       end
 
+      it 'make success when value is basic object' do
+        object = BasicObject.new
+        subject.deep_update(basic_obj: object)
+        expect(subject.basic_obj).to equal object
+      end
+
       it 'converts values only once' do
         class ConvertedMash < Hashie::Mash
         end


### PR DESCRIPTION
When I used `Hashie::Mash` in my program, I found my test is raised at `_deep_update` as follows:
```bash
NoMethodError: unmocked method :is_a?, expected one of []
    /Users/eagle/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/hashie-4.1.0/lib/hashie/mash.rb:250:in `block in _deep_update'
    /Users/eagle/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/hashie-4.1.0/lib/hashie/mash.rb:248:in `each_pair'
    /Users/eagle/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/hashie-4.1.0/lib/hashie/mash.rb:248:in `_deep_update'
    /Users/eagle/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/hashie-4.1.0/lib/hashie/mash.rb:221:in `block in deep_update'
```
The reason is that my test is using mock, so if want to be pass, I must add method `is_a?`, it's not very well. I have submited the spec, please check it out.