### PR TITLE
Add #except under Ruby 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Added
 
+* [#545](https://github.com/hashie/hashie/pull/545): Add `Hashie::Mash#except` and `Hashie::Extensions::IndifferentAccess#except` when running under Ruby 3 to match newly added Ruby stdlib method - [@jackjennings](https://github.com/jackjennings).
 * [#499](https://github.com/hashie/hashie/pull/499): Add `Hashie::Extensions::Mash::PermissiveRespondTo` to make specific subclasses of Mash fully respond to messages for use with `SimpleDelegator` - [@michaelherold](https://github.com/michaelherold).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Any violations of this scheme are considered to be bugs.
 
 * [#516](https://github.com/hashie/hashie/issues/516): Fixed `NoMethodError` raised when including `Hashie::Extensions::Mash::SymbolizeKeys` and `Hashie::Extensions::SymbolizeKeys` in mashes/hashes with non string or symbol keys - [@carolineartz](https://github.com/carolineartz).
 * [#531](https://github.com/hashie/hashie/pull/531): Fixed [slice doesn't work using symbols](https://github.com/hashie/hashie/issues/529) using hash with `IndifferentAccess` extension - [@gnomex](https://github.com/gnomex).
-* [#533](https://github.com/hashie/hashie/pull/533): Fixed `NoMethodError: undefined method `to_json'` at `hashie/dash_spec` - [@gnomex](https://github.com/gnomex).
+* [#533](https://github.com/hashie/hashie/pull/533): Fixed `NoMethodError: undefined method 'to_json'` at `hashie/dash_spec` - [@gnomex](https://github.com/gnomex).
 * [#537](https://github.com/hashie/hashie/pull/537): Fixed inconsistencies with handling defaults in `Dash` with and without `IgnoreUnclared` mixed in - [@michaelherold](https://github.com/michaelherold).
 * Your contribution here.
 

--- a/lib/hashie/extensions/indifferent_access.rb
+++ b/lib/hashie/extensions/indifferent_access.rb
@@ -162,6 +162,13 @@ module Hashie
         end
       end
 
+      with_minimum_ruby('3.0.0') do
+        def except(*keys)
+          string_keys = keys.map { |key| convert_key(key) }
+          super(*string_keys)
+        end
+      end
+
       protected
 
       def hash_lacking_indifference?(other)

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -351,6 +351,13 @@ module Hashie
       end
     end
 
+    with_minimum_ruby('3.0.0') do
+      def except(*keys)
+        string_keys = keys.map { |key| convert_key(key) }
+        self.class.new(super(*string_keys))
+      end
+    end
+
     protected
 
     def method_name_and_suffix(method_name)

--- a/spec/hashie/extensions/indifferent_access_spec.rb
+++ b/spec/hashie/extensions/indifferent_access_spec.rb
@@ -357,6 +357,18 @@ describe Hashie::Extensions::IndifferentAccess do
         end
       end
     end
+
+    with_minimum_ruby('3.0.0') do
+      describe '#except' do
+        let(:h) { subject.build(foo: 'bar', baz: 'qux') }
+
+        it 'indifferently excepts keys from the hash' do
+          sliced_h = { 'baz' => 'qux' }
+          expect(h.except('foo')).to eq sliced_h
+          expect(h.except(:foo)).to eq sliced_h
+        end
+      end
+    end
   end
 
   describe 'with merge initializer' do

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -1097,4 +1097,17 @@ describe Hashie::Mash do
       end
     end
   end
+
+  with_minimum_ruby('3.0.0') do
+    context '#except' do
+      subject(:mash) { described_class.new(a: 'A', b: 'B') }
+      it 'return a Hashie::Mash' do
+        expect(mash.except(:b)).to be_kind_of(described_class)
+      end
+
+      it 'excludes keys' do
+        expect(mash.except(:b)).to eq('a' => 'A')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Ruby 3 adds the Hash#except method, which should return the correct Hashie object instance when called on a Mash or object using the Hashie::Extensions::IndifferentAccess mixin.

This change implements `#except` in both of those locations and adds the corresponding specs.