### PR TITLE
make #deep_find_all behave more like Enumerable#find_all

### DIFF
--- a/lib/hashie/extensions/deep_find.rb
+++ b/lib/hashie/extensions/deep_find.rb
@@ -46,7 +46,7 @@ module Hashie
       #  my_hash.deep_find_all(:address) # => ['123 Street', '234 Street']
       def deep_find_all(key)
         matches = _deep_find_all(key)
-        matches.empty? ? nil : matches
+        matches.empty? ? [] : matches
       end
 
       alias deep_select deep_find_all

--- a/spec/hashie/extensions/deep_find_spec.rb
+++ b/spec/hashie/extensions/deep_find_spec.rb
@@ -39,8 +39,8 @@ describe Hashie::Extensions::DeepFind do
         .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
     end
 
-    it 'returns nil if it does not find any matches' do
-      expect(instance.deep_find_all(:wahoo)).to be_nil
+    it 'returns empty array if it does not find any matches' do
+      expect(instance.deep_find_all(:wahoo)).to eq([])
     end
 
     context 'when match value is hash itself' do
@@ -99,9 +99,9 @@ describe Hashie::Extensions::DeepFind do
           .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
       end
 
-      it 'indifferently returns nil if it does not find any matches' do
-        expect(instance.deep_find_all(:wahoo)).to be_nil
-        expect(instance.deep_find_all('wahoo')).to be_nil
+      it 'indifferently returns empty array if it does not find any matches' do
+        expect(instance.deep_find_all(:wahoo)).to eq([])
+        expect(instance.deep_find_all('wahoo')).to eq([])
       end
     end
   end

--- a/spec/integration/active_support/integration_spec.rb
+++ b/spec/integration/active_support/integration_spec.rb
@@ -66,9 +66,9 @@ RSpec.describe Hashie::Extensions::DeepFind do
         .to eq(['Call of the Wild', 'Moby Dick', 'Main Library'])
     end
 
-    it 'indifferently returns nil if it does not find any matches' do
-      expect(instance.deep_find_all(:wahoo)).to be_nil
-      expect(instance.deep_find_all('wahoo')).to be_nil
+    it 'indifferently returns empty array if it does not find any matches' do
+      expect(instance.deep_find_all(:wahoo)).to eq([])
+      expect(instance.deep_find_all('wahoo')).to eq([])
     end
   end
 end


### PR DESCRIPTION
I was kind of surprised by the choice of returning `nil` when there are no matches when calling `#deep_find_all` as the default behavior from `Enumerable#find_all` is to return an empty array if no matches are found. 

```
[1] pry(main)> (1..10).find_all { |i| i > 11 }
=> []
```
This PR changes the behavior to closer match core Ruby functionality.

The main driver behind this is to be able to do things like:
`hash.deep_find_all(:some_key).sum(&:to_i)` without having to resort to making helper methods like the following:

```
def deep_select(hash, key)
  hash.deep_find_all(key) || []
end
``` 