### PR TITLE
Fix: use a personal danger token.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,27 +4,23 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
+  pull_request:
     branches:
       - master
 
 jobs:
   danger:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request_target' }}
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: 2.7
-    - uses: MeilCli/danger-action@v5
-      with:
-        danger_file: Dangerfile
-        danger_id: danger-pr
-        install_path: vendor/bundle
-        plugins_file: Gemfile
-      env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.github_token }}
+      run: |
+        # the personal token is public, this is ok, base64 encode to avoid tripping Github
+        TOKEN=$(echo -n NWY1ZmM5MzEyMzNlYWY4OTZiOGU3MmI3MWQ3Mzk0MzgxMWE4OGVmYwo= | base64 --decode)
+        DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
 
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Danger can't find the commit in the PR because it's missing a token (?).

```
RuntimeError: Commit 9ba96e03 doesn't exist. Are you running `danger local/pr` against the correct repository? Also this usually happens when you rebase/reset and force-pushed.
  /home/runner/work/hashie/hashie/vendor/bundle/ruby/2.7.0/gems/danger-8.4.1/lib/danger/scm_source/git_repo.rb:117:in `raise_if_we_cannot_find_the_commit'
  /home/runner/work/hashie/hashie/vendor/bundle/ruby/2.7.0/gems/danger-8.4.1/lib/danger/scm_source/git_repo.rb:99:in `ensure_commitish_exists_on_branch!'
  /home/runner/work/hashie/hashie/vendor/bundle/ruby/2.7.0/gems/danger-8.4.1/lib/danger/request_sources/github/github.rb:116:in `setup_danger_branches'
  /home/runner/work/hashie/hashie/vendor/bundle/ruby/2.7.0/gems/danger-8.4.1/lib/danger/danger_core/environment_manager.rb:58:in `ensure_danger_branches_are_setup'
  /home/runner/work/hashie/hashie/vendor/bundle/ruby/2.7.0/gems/danger-8.4.1/lib/danger/danger_core/dangerfile.rb:273:in `setup_for_running'
```

This seems to be https://github.com/danger/danger/issues/1103