### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.0
+          - 3.1
+          - '3.0'
           - 2.7
           - 2.6
           - 2.5
@@ -70,6 +71,8 @@ jobs:
     - name: Install dependencies
       run: bundle install --jobs 4 --retry 3
     - name: Run tests
+      env:
+        RUBYOPT: "--disable-error_highlight"
       run: bundle exec rake
 
   test-jruby:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,15 +52,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 3.1
+          - '3.1'
           - '3.0'
-          - 2.7
-          - 2.6
-          - 2.5
-          - 2.4
-          - 2.3
-          - 2.2
-          - 2.1
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
 inherit_from: .rubocop_todo.yml
 
 # Disabled until we can use the squiggly heredoc (after deprecating Ruby <2.3)
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 
 Metrics/ClassLength:
@@ -42,4 +42,7 @@ Naming/FileName:
 # use double negation, there isn't a means that as succinct of doing the type of
 # boolean casting that we do.
 Style/DoubleNegation:
+  Enabled: false
+
+Style/HashSyntax:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Changed
 
-* Your contribution here.
+* [#558](https://github.com/hashie/hashie/pull/558): Test with Ruby 3.1 - [@petergoldstein](https://github.com/petergoldstein).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Changed
 
+* Your contribution here.
 * [#558](https://github.com/hashie/hashie/pull/558): Test with Ruby 3.1 - [@petergoldstein](https://github.com/petergoldstein).
 
 ### Deprecated

--- a/Gemfile
+++ b/Gemfile
@@ -13,25 +13,11 @@ group :development do
   gem 'pry'
   gem 'pry-stack_explorer', platforms: %i[ruby_19 ruby_20 ruby_21]
 
-  # rubocop:disable Bundler/DuplicatedGem
-  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
-     Hashie::Extensions::RubyVersion.new('2.4.0')
-    gem 'rubocop', '~> 1.0'
-  else
-    gem 'rubocop', '0.52.1'
-  end
-  # rubocop:enable Bundler/DuplicatedGem
+  gem 'rubocop', '~> 1.0'
 
   group :test do
     # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
-    # rubocop:disable Bundler/DuplicatedGem
-    if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
-       Hashie::Extensions::RubyVersion.new('2.4.0')
-      gem 'activesupport', '~> 5.x', require: false
-    else
-      gem 'activesupport', '~> 4.x', require: false
-    end
-    # rubocop:enable Bundler/DuplicatedGem
+    gem 'activesupport', '~> 5.x', require: false
     gem 'rake'
     gem 'rspec', '~> 3'
     gem 'rspec-pending_for', '~> 0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'http://rubygems.org'
 
 gemspec
 
+require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
+
 group :development do
   gem 'benchmark-ips'
   gem 'benchmark-memory'
@@ -10,12 +12,19 @@ group :development do
   gem 'guard-yield', '~> 0.1.0', require: false
   gem 'pry'
   gem 'pry-stack_explorer', platforms: %i[ruby_19 ruby_20 ruby_21]
-  gem 'rubocop', '0.52.1'
+
+  # rubocop:disable Bundler/DuplicatedGem
+  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+     Hashie::Extensions::RubyVersion.new('2.4.0')
+    gem 'rubocop', '~> 1.0'
+  else
+    gem 'rubocop', '0.52.1'
+  end
+  # rubocop:enable Bundler/DuplicatedGem
 
   group :test do
     # ActiveSupport required to test compatibility with ActiveSupport Core Extensions.
     # rubocop:disable Bundler/DuplicatedGem
-    require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
     if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
        Hashie::Extensions::RubyVersion.new('2.4.0')
       gem 'activesupport', '~> 5.x', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'http://rubygems.org'
 
 gemspec
 
-require File.expand_path('../lib/hashie/extensions/ruby_version', __FILE__)
-
 group :development do
   gem 'benchmark-ips'
   gem 'benchmark-memory'
@@ -11,7 +9,6 @@ group :development do
   gem 'guard-rspec', '~> 4.3.1', require: false
   gem 'guard-yield', '~> 0.1.0', require: false
   gem 'pry'
-  gem 'pry-stack_explorer', platforms: %i[ruby_19 ruby_20 ruby_21]
 
   gem 'rubocop', '~> 1.0'
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'spec/support/integration_specs'
 
 run_all = lambda do |*|

--- a/Rakefile
+++ b/Rakefile
@@ -32,10 +32,4 @@ task :integration_specs do
   end
 end
 
-# Disable Rubocop for older versions of Ruby
-if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) <
-   Hashie::Extensions::RubyVersion.new('2.4.0')
-  task default: %i[spec integration_specs]
-else
-  task default: %i[rubocop spec integration_specs]
-end
+task default: %i[rubocop spec integration_specs]

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 Bundler.setup
@@ -16,6 +18,7 @@ RuboCop::RakeTask.new(:rubocop)
 require_relative 'spec/support/integration_specs'
 task :integration_specs do
   next if ENV['CI']
+
   status_codes = []
   handler = lambda do |status_code|
     status_codes << status_code unless status_code.zero?
@@ -29,4 +32,10 @@ task :integration_specs do
   end
 end
 
-task default: %i[rubocop spec integration_specs]
+# Disable Rubocop for older versions of Ruby
+if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) <
+   Hashie::Extensions::RubyVersion.new('2.4.0')
+  task default: %i[spec integration_specs]
+else
+  task default: %i[rubocop spec integration_specs]
+end

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'hashie'

--- a/hashie.gemspec
+++ b/hashie.gemspec
@@ -24,5 +24,7 @@ Gem::Specification.new do |gem|
     }
   end
 
+  gem.required_ruby_version = '>= 2.4'
+
   gem.add_development_dependency 'bundler'
 end

--- a/lib/hashie/extensions/coercion.rb
+++ b/lib/hashie/extensions/coercion.rb
@@ -17,14 +17,7 @@ module Hashie
       }.freeze
 
       ABSTRACT_CORE_TYPES =
-        if RubyVersion.new(RUBY_VERSION) >= RubyVersion.new('2.4.0')
-          { Numeric => [Integer, Float, Complex, Rational] }
-        else
-          {
-            Integer => [Fixnum, Bignum],
-            Numeric => [Fixnum, Bignum, Float, Complex, Rational]
-          }
-        end
+        { Numeric => [Integer, Float, Complex, Rational] }
 
       def self.included(base)
         base.send :include, InstanceMethods

--- a/lib/hashie/mash.rb
+++ b/lib/hashie/mash.rb
@@ -322,22 +322,18 @@ module Hashie
       self.class.new(other_hash).merge(self)
     end
 
-    with_minimum_ruby('2.3.0') do
-      def dig(*keys)
-        super(*keys.map { |key| convert_key(key) })
-      end
+    def dig(*keys)
+      super(*keys.map { |key| convert_key(key) })
     end
 
-    with_minimum_ruby('2.4.0') do
-      def transform_values(&blk)
-        self.class.new(super(&blk))
-      end
+    def transform_values(&blk)
+      self.class.new(super(&blk))
+    end
 
-      # Returns a new instance of the class it was called on, with nil values
-      # removed.
-      def compact
-        self.class.new(super)
-      end
+    # Returns a new instance of the class it was called on, with nil values
+    # removed.
+    def compact
+      self.class.new(super)
     end
 
     with_minimum_ruby('2.5.0') do

--- a/lib/hashie/version.rb
+++ b/lib/hashie/version.rb
@@ -1,3 +1,3 @@
 module Hashie
-  VERSION = '5.0.1'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/spec/hashie/array_spec.rb
+++ b/spec/hashie/array_spec.rb
@@ -1,28 +1,26 @@
 require 'spec_helper'
 
 describe Array do
-  with_minimum_ruby('2.3.0') do
-    describe '#dig' do
-      let(:array) { Hashie::Array.new(%i[a b c]) }
+  describe '#dig' do
+    let(:array) { Hashie::Array.new(%i[a b c]) }
 
-      it 'works with a string index' do
-        expect(array.dig('0')).to eq(:a)
+    it 'works with a string index' do
+      expect(array.dig('0')).to eq(:a)
+    end
+
+    it 'works with a numeric index' do
+      expect(array.dig(1)).to eq(:b)
+    end
+
+    context 'when array is empty' do
+      let(:array) { Hashie::Array.new([]) }
+
+      it 'works with a first numeric and next string index' do
+        expect(array.dig(0, 'hello')).to eq(nil)
       end
 
-      it 'works with a numeric index' do
-        expect(array.dig(1)).to eq(:b)
-      end
-
-      context 'when array is empty' do
-        let(:array) { Hashie::Array.new([]) }
-
-        it 'works with a first numeric and next string index' do
-          expect(array.dig(0, 'hello')).to eq(nil)
-        end
-
-        it 'throws an error with first string and next numeric index' do
-          expect { array.dig('hello', 0) }.to raise_error(TypeError)
-        end
+      it 'throws an error with first string and next numeric index' do
+        expect { array.dig('hello', 0) }.to raise_error(TypeError)
       end
     end
   end

--- a/spec/hashie/extensions/coercion_spec.rb
+++ b/spec/hashie/extensions/coercion_spec.rb
@@ -563,13 +563,7 @@ describe Hashie::Extensions::Coercion do
       end
 
       it 'raises a CoercionError when coercion is not possible' do
-        type =
-          if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
-             Hashie::Extensions::RubyVersion.new('2.4.0')
-            Integer
-          else
-            Fixnum
-          end
+        type = Integer
 
         subject.coerce_value type, Symbol
         expect { instance[:hi] = 1 }.to raise_error(
@@ -578,13 +572,7 @@ describe Hashie::Extensions::Coercion do
       end
 
       it 'coerces Integer to String' do
-        type =
-          if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
-             Hashie::Extensions::RubyVersion.new('2.4.0')
-            Integer
-          else
-            Fixnum
-          end
+        type = Integer
 
         subject.coerce_value type, String
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -649,8 +649,7 @@ describe Hashie::Mash do
 
     context 'when key does not exist' do
       it 'raises KeyError' do
-        error = RUBY_VERSION =~ /1.8/ ? IndexError : KeyError
-        expect { mash.fetch(:two) }.to raise_error(error)
+        expect { mash.fetch(:two) }.to raise_error(KeyError)
       end
 
       context 'with default value given' do
@@ -980,44 +979,40 @@ describe Hashie::Mash do
     end
   end
 
-  with_minimum_ruby('2.3.0') do
-    describe '#dig' do
-      subject { described_class.new(a: { b: 1 }) }
+  describe '#dig' do
+    subject { described_class.new(a: { b: 1 }) }
 
-      it 'accepts both string and symbol as key' do
-        expect(subject.dig(:a, :b)).to eq(1)
-        expect(subject.dig('a', 'b')).to eq(1)
-      end
+    it 'accepts both string and symbol as key' do
+      expect(subject.dig(:a, :b)).to eq(1)
+      expect(subject.dig('a', 'b')).to eq(1)
+    end
 
-      context 'when the Mash wraps a Hashie::Array' do
-        it 'handles digging into an array' do
-          mash = described_class.new(alphabet: { first_three: Hashie::Array['a', 'b', 'c'] })
+    context 'when the Mash wraps a Hashie::Array' do
+      it 'handles digging into an array' do
+        mash = described_class.new(alphabet: { first_three: Hashie::Array['a', 'b', 'c'] })
 
-          expect(mash.dig(:alphabet, :first_three, 0)).to eq 'a'
-        end
+        expect(mash.dig(:alphabet, :first_three, 0)).to eq 'a'
       end
     end
   end
 
-  with_minimum_ruby('2.4.0') do
-    describe '#transform_values' do
-      subject(:mash) { described_class.new(a: 1) }
+  describe '#transform_values' do
+    subject(:mash) { described_class.new(a: 1) }
 
-      it 'returns a Hashie::Mash' do
-        expect(mash.transform_values(&:to_s)).to be_kind_of(described_class)
-      end
+    it 'returns a Hashie::Mash' do
+      expect(mash.transform_values(&:to_s)).to be_kind_of(described_class)
+    end
 
-      it 'transforms the value' do
-        expect(mash.transform_values(&:to_s).a).to eql('1')
-      end
+    it 'transforms the value' do
+      expect(mash.transform_values(&:to_s).a).to eql('1')
+    end
 
-      context 'when using with subclass' do
-        let(:subclass) { Class.new(Hashie::Mash) }
-        subject(:sub_mash) { subclass.new(a: 1).transform_values { |a| a + 2 } }
+    context 'when using with subclass' do
+      let(:subclass) { Class.new(Hashie::Mash) }
+      subject(:sub_mash) { subclass.new(a: 1).transform_values { |a| a + 2 } }
 
-        it 'creates an instance of subclass' do
-          expect(sub_mash).to be_kind_of(subclass)
-        end
+      it 'creates an instance of subclass' do
+        expect(sub_mash).to be_kind_of(subclass)
       end
     end
 

--- a/spec/integration/omniauth/Rakefile
+++ b/spec/integration/omniauth/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :perf do
   task :setup do
     require 'omniauth'
@@ -12,6 +14,7 @@ namespace :perf do
     def call_app(path = ENV['GET_PATH'] || '/')
       result = @app.get(path)
       raise "Did not succeed #{result.body}" unless result.status == 200
+
       result
     end
   end

--- a/spec/support/integration_specs.rb
+++ b/spec/support/integration_specs.rb
@@ -4,7 +4,12 @@
 # @param [String] command the command to run
 # @return [String]
 def integration_command(integration, command)
-  "#{integration_gemfile(integration)} #{command}"
+  if Hashie::Extensions::RubyVersion.new(RUBY_VERSION) >=
+     Hashie::Extensions::RubyVersion.new('3.1.0')
+     ruby_opts = "RUBYOPT=--disable-error_highlight "
+  end
+
+  "#{ruby_opts}#{integration_gemfile(integration)} #{command}"
 end
 
 # Generates the Gemfile for an integration

--- a/spec/support/integration_specs.rb
+++ b/spec/support/integration_specs.rb
@@ -1,3 +1,5 @@
+require File.expand_path('../../../lib/hashie/extensions/ruby_version', __FILE__)
+
 # Generates the bundle command for running an integration test
 #
 # @param [String] integration the integration folder to run


### PR DESCRIPTION
In addition to adding Ruby 3.1 to the CI configuration a number of other changes were required to get everything to pass.  This included:

- Updating Rubocop to ~> 1.0 for Rubies 2.4 and greater
- Disabling the Rubocop run in rake for Rubies before Ruby 2.4
- Quoting '3.0' in the CI configuration to ensure it loads a 3.0.x Ruby
- Set RUBYOPT="--disable_error_highlight" so Ruby 3.1 error matchers pass (both in CI configuration and in integration spec command)
- Fixing a few trivial lints