### PR TITLE
Add dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will ensure that GitHub Actions stay up to date.  As the checkout action is currently out of date, Dependabot should open a PR to update it after this PR is merged.