### PR TITLE
Feature: Mash::UnderscoreKeys Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,30 @@ end
 
 However, on Rubies less than 2.0, this means that every key you send to the Mash will generate a symbol. Since symbols are not garbage-collected on older versions of Ruby, this can cause a slow memory leak when using a symbolized Mash with data generated from user input.
 
+### UnderscoreKeys
+This extension can be mixed into a Mash to change the default behavior of converting keys to be underscore. After mixing this extension into a Mash, the Mash will convert all string keys to underscore. It can be useful to use with external source hashes, which maybe contain hyphens or CamelCase.
+
+```ruby
+class UnderscoreMash < ::Hashie::Mash
+  include Hashie::Extensions::Mash::UnderscoreKeys
+end
+
+mash = UnderscoreMash.new
+mash.updatedAt = 'Today' #=> 'Today'
+mash.updatedAt #=> 'Today'
+mash[:updated_at] #=> 'Today'
+mash['updated_at'] #=> 'Today'
+mash.updated_at #=> 'Today'
+mash.to_hash #=> {"updated_at"=>true}
+```
+
+The other benefit is hashes that have hyphens can be accessed with methods
+```ruby
+mash = UnderscoreMash.new('created-at': 'tomorrow') #=> {"created_at"=>"tomorrow"}
+
+mash.created_at #=> 'tomorrow'
+```
+
 ### DefineAccessors
 
 This extension can be mixed into a Mash so it makes it behave like `OpenStruct`. It reduces the overhead of `method_missing?` magic by lazily defining field accessors when they're requested.

--- a/lib/hashie.rb
+++ b/lib/hashie.rb
@@ -50,6 +50,7 @@ module Hashie
       autoload :SafeAssignment, 'hashie/extensions/mash/safe_assignment'
       autoload :SymbolizeKeys, 'hashie/extensions/mash/symbolize_keys'
       autoload :DefineAccessors, 'hashie/extensions/mash/define_accessors'
+      autoload :UnderscoreKeys, 'hashie/extensions/mash/underscore_keys'
     end
 
     module Array

--- a/lib/hashie/extensions/mash/underscore_keys.rb
+++ b/lib/hashie/extensions/mash/underscore_keys.rb
@@ -1,0 +1,40 @@
+module Hashie
+  module Extensions
+    module Mash
+      # Overrides the indifferent access of a Mash to keep keys in
+      # underscore format.
+      #
+      # @example
+      #   class UnderscoreMash < ::Hashie::Mash
+      #     include Hashie::Extensions::Mash::UnderscoreKeys
+      #   end
+      #
+      #   mash = UnderscoreMash.new(symbolKey: { dataFrom: { java: true, javaScript: true } })
+      #   mash.symbol_key.data_from.java #=> true
+      #   mash.symbolKey.dataFrom.java_script  #=> true
+      module UnderscoreKeys
+        def self.included(base)
+          raise ArgumentError, "#{base} must descent from Hashie::Mash" unless base <= Hashie::Mash
+        end
+
+        private
+
+        def _underscore(string)
+          string.gsub(/::/, '/')
+                .gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2')
+                .gsub(/([a-z\d])([A-Z])/,'\1_\2')
+                .tr('-', '_')
+                .downcase
+        end
+
+        # Ensures all keys are underscore formatting.
+        #
+        # @param [Object, String, Symbol] key the key to access.
+        # @return [Object] the value assigned to the key.
+        def convert_key(key)
+          _underscore(key.to_s) if key.is_a?(String) || key.is_a?(Symbol)
+        end
+      end
+    end
+  end
+end

--- a/spec/hashie/extensions/autoload_spec.rb
+++ b/spec/hashie/extensions/autoload_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'hashie'
 
 describe Hashie::Extensions do
-  describe 'autloads constants' do
+  describe 'autoloads constants' do
     it { is_expected.to be_const_defined(:MethodAccess) }
     it { is_expected.to be_const_defined(:Coercion) }
     it { is_expected.to be_const_defined(:DeepMerge) }

--- a/spec/hashie/extensions/mash/underscrore_keys_spec.rb
+++ b/spec/hashie/extensions/mash/underscrore_keys_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe Hashie::Extensions::Mash::UnderscoreKeys, :aggregate_failures do
+  let(:underscore_mash) do
+    Class.new(Hashie::Mash) do
+      include Hashie::Extensions::Mash::UnderscoreKeys
+    end
+  end
+
+  it 'allows access to keys via original name' do
+    original = {
+      dataFrom: { java: true, javaScript: true },
+      DataSource: { GitHub: true },
+      'created-at': 'today'
+    }
+
+    mash = underscore_mash.new(original)
+
+    expect(mash.dataFrom.java).to be(true)
+    expect(mash[:dataFrom][:java]).to be(true)
+    expect(mash['dataFrom']['java']).to be(true)
+
+    expect(mash.dataFrom.javaScript).to be(true)
+    expect(mash[:dataFrom][:javaScript]).to be(true)
+    expect(mash['dataFrom']['javaScript']).to be(true)
+
+    expect(mash.DataSource.GitHub).to be(true)
+    expect(mash[:DataSource][:GitHub]).to be(true)
+    expect(mash['DataSource']['GitHub']).to be(true)
+
+    # can't currently call a method with a hyphen
+    # expect(mash.call(:'created-at')).to eq('today')
+    expect(mash[:'created-at']).to eq('today')
+    expect(mash['created-at']).to eq('today')
+  end
+
+  it 'allows access to underscore key names' do
+    original = {
+      dataFrom: { java: true, javaScript: true },
+      DataSource: { GitHub: true },
+      'created-at': 'today'
+    }
+
+    mash = underscore_mash.new(original)
+
+    expect(mash.data_from.java).to be(true)
+    expect(mash[:data_from][:java]).to be(true)
+    expect(mash['data_from']['java']).to be(true)
+
+    expect(mash.data_from.java_script).to be(true)
+    expect(mash[:data_from][:java_script]).to be(true)
+    expect(mash['data_from']['java_script']).to be(true)
+
+    expect(mash.data_source.git_hub).to be(true)
+    expect(mash[:data_source][:git_hub]).to be(true)
+    expect(mash['data_source']['git_hub']).to be(true)
+
+    expect(mash.created_at).to eq('today')
+    expect(mash[:'created-at']).to eq('today')
+    expect(mash['created-at']).to eq('today')
+  end
+
+  it 'allows mixing and matching of underscore and camelCase' do
+    original = {
+      dataFrom: { java: true, javaScript: true },
+      DataSource: { GitHub: true },
+      'created-at': 'today'
+    }
+
+    mash = underscore_mash.new(original)
+
+    expect(mash.dataFrom.java_script).to be(true)
+    expect(mash[:data_from][:javaScript]).to be(true)
+    expect(mash['dataFrom']['java_script']).to be(true)
+
+    expect(mash.DataSource.git_hub).to be(true)
+    expect(mash[:data_source][:GitHub]).to be(true)
+    expect(mash['DataSource']['git_hub']).to be(true)
+  end
+end


### PR DESCRIPTION
This extension can be mixed into a Mash to change the default behavior of converting keys to be underscore. After mixing this extension into a Mash, the Mash will convert all string keys to underscore. It can be useful to use with external source hashes, which maybe contain hyphens or CamelCase.

```ruby
class UnderscoreMash < ::Hashie::Mash
  include Hashie::Extensions::Mash::UnderscoreKeys
end
mash = UnderscoreMash.new
mash.updatedAt = 'Today' #=> 'Today'
mash.updatedAt #=> 'Today'
mash[:updated_at] #=> 'Today'
mash['updated_at'] #=> 'Today'
mash.updated_at #=> 'Today'
mash.to_hash #=> {"updated_at"=>true}
```

The other benefit is hashes that have hyphens can be accessed with methods
```ruby
mash = UnderscoreMash.new('created-at': 'tomorrow') #=> {"created_at"=>"tomorrow"}
mash.created_at #=> 'tomorrow'
```