### PR TITLE
new integration spec for rails 7 exhibiting failure when executing de…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ Any violations of this scheme are considered to be bugs.
 
 ### Miscellaneous
 
-* [#569](https://github.com/hashie/hashie/pull/569): Added pending spec related to issue [#559](https://github.com/hashie/hashie/issues/559) when calling `#deep_transform_keys` on instance of `Hashie::Dash` w/ Rails 7 - [@aflansburg](https://github.com/aflansburg)
+* Your contribution here.
+
+* [#569](https://github.com/hashie/hashie/pull/569): Added support for Rails 7 - [@aflansburg](https://github.com/aflansburg).
 
 ## [5.0.0] - 2021-11-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Miscellaneous
 
-* Your contribution here.
+* [#569](https://github.com/hashie/hashie/pull/569): Added pending spec related to issue [#559](https://github.com/hashie/hashie/issues/559) when calling `#deep_transform_keys` on instance of `Hashie::Dash` w/ Rails 7 - [@aflansburg](https://github.com/aflansburg)
 
 ## [5.0.0] - 2021-11-08
 

--- a/spec/integration/rails_7/.rspec
+++ b/spec/integration/rails_7/.rspec
@@ -1,0 +1,3 @@
+--colour
+--format=documentation
+--pattern=*_spec.rb

--- a/spec/integration/rails_7/Gemfile
+++ b/spec/integration/rails_7/Gemfile
@@ -1,0 +1,6 @@
+source 'http://rubygems.org'
+
+gem 'hashie', path: '../../..'
+gem 'rails', '~> 7.0.0'
+gem 'rspec', '~> 3.5.0'
+gem 'rspec-rails'

--- a/spec/integration/rails_7/app.rb
+++ b/spec/integration/rails_7/app.rb
@@ -1,0 +1,40 @@
+require 'action_controller/railtie'
+require 'action_view/railtie'
+require 'action_view/testing/resolvers'
+require 'rails/test_unit/railtie'
+
+module RailsApp
+  class Application < ::Rails::Application
+    config.eager_load      = false
+    config.secret_key_base = 'hashieintegrationtest'
+
+    routes.append do
+      get '/' => 'application#index'
+    end
+  end
+end
+
+PAGE = <<-HTML.freeze
+<!DOCTYPE html>
+<html>
+<head>
+  <title>TestApp</title>
+  <%= csrf_meta_tags %>
+</head>
+<body>
+  <h1>Hello, world!</h1>
+</body>
+</html>
+HTML
+
+class ApplicationController < ActionController::Base
+  include Rails.application.routes.url_helpers
+
+  def index
+    render inline: PAGE
+  end
+end
+
+Bundler.require(:default, Rails.env)
+
+RailsApp::Application.initialize!

--- a/spec/integration/rails_7/integration_spec.rb
+++ b/spec/integration/rails_7/integration_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'rails', type: :request do
     subject(:hash) { klass.new(foo_bar: 'bar', foo_baz: 'baz') }
 
     it 'sucessfully deep transforms keys' do
-      pending('resolution of https://github.com/hashie/hashie/issues/559')
+      pending('deep transform keys')
       transformed = hash.deep_transform_keys(&:to_s)
       expect(transformed.keys).to all(be_a(String))
     end

--- a/spec/integration/rails_7/integration_spec.rb
+++ b/spec/integration/rails_7/integration_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe 'rails', type: :request do
         property :foo_bar
         property :foo_baz, required: true
       end
+      pending('resolution of https://github.com/hashie/hashie/issues/559')
       dash_klass = HashieDashKlass.new(foo_bar: 'bar', foo_baz: 'baz')
       transformed = dash_klass.deep_transform_keys(&:to_s)
       expect(transformed.keys).to all(be_a(String))

--- a/spec/integration/rails_7/integration_spec.rb
+++ b/spec/integration/rails_7/integration_spec.rb
@@ -41,14 +41,18 @@ RSpec.describe 'rails', type: :request do
   end
 
   context '#deep_transform_keys' do
-    it 'sucessfully deep transforms keys' do
-      class HashieDashKlass < Hashie::Dash
-        property :foo_bar
+    let(:klass) do
+      Class.new(Hashie::Dash) do
+        property :foo_bar 
         property :foo_baz, required: true
       end
+    end
+    
+    subject(:hash) { klass.new(foo_bar: 'bar', foo_baz: 'baz') }
+
+    it 'sucessfully deep transforms keys' do
       pending('resolution of https://github.com/hashie/hashie/issues/559')
-      dash_klass = HashieDashKlass.new(foo_bar: 'bar', foo_baz: 'baz')
-      transformed = dash_klass.deep_transform_keys(&:to_s)
+      transformed = hash.deep_transform_keys(&:to_s)
       expect(transformed.keys).to all(be_a(String))
     end
   end

--- a/spec/integration/rails_7/integration_spec.rb
+++ b/spec/integration/rails_7/integration_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'rails', type: :request do
     subject(:hash) { klass.new(foo_bar: 'bar', foo_baz: 'baz') }
 
     it 'sucessfully deep transforms keys' do
-      pending('deep transform keys')
+      pending('https://github.com/hashie/hashie/issues/559')
       transformed = hash.deep_transform_keys(&:to_s)
       expect(transformed.keys).to all(be_a(String))
     end

--- a/spec/integration/rails_7/integration_spec.rb
+++ b/spec/integration/rails_7/integration_spec.rb
@@ -1,0 +1,59 @@
+ENV['RAILS_ENV'] = 'test'
+
+require 'rspec/core'
+
+RSpec.describe 'rails', type: :request do
+  let(:stdout) { StringIO.new }
+
+  around(:each) do |example|
+    original_stdout = $stdout
+    $stdout = stdout
+    require_relative 'app'
+    require 'rspec/rails'
+    example.run
+    $stdout = original_stdout
+  end
+
+  it 'does not log anything to STDOUT when initializing' do
+    expect(stdout.string).to eq('')
+  end
+
+  it 'sets the Hashie logger to the Rails logger' do
+    expect(Hashie.logger).to eq(Rails.logger)
+  end
+
+  context '#except' do
+    subject { Hashie::Mash.new(x: 1, y: 2) }
+
+    it 'returns an instance of the class it was called on' do
+      class HashieKlass < Hashie::Mash; end
+      hashie_klass = HashieKlass.new(subject)
+      expect(hashie_klass.except('x')).to be_a HashieKlass
+    end
+
+    it 'works with string keys' do
+      expect(subject.except('x')).to eq Hashie::Mash.new(y: 2)
+    end
+
+    it 'works with symbol keys' do
+      expect(subject.except(:x)).to eq Hashie::Mash.new(y: 2)
+    end
+  end
+
+  context '#deep_transform_keys' do
+    it 'sucessfully deep transforms keys' do
+      class HashieDashKlass < Hashie::Dash
+        property :foo_bar
+        property :foo_baz, required: true
+      end
+      dash_klass = HashieDashKlass.new(foo_bar: 'bar', foo_baz: 'baz')
+      transformed = dash_klass.deep_transform_keys(&:to_s)
+      expect(transformed.keys).to all(be_a(String))
+    end
+  end
+
+  it 'works' do
+    get '/'
+    assert_select 'h1', 'Hello, world!'
+  end
+end


### PR DESCRIPTION
New integration spec for Rails 7 to exhibit failure mentioned in https://github.com/hashie/hashie/issues/559 when applying `deep_transform_keys` (or any `deep_<op>_keys` for that matter on `Hashie::Dash` or inheriting classes.