### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -17,5 +17,5 @@ jobs:
       run: |
         bundle install
         # the personal token is public, this is ok, base64 encode to avoid tripping Github
-        TOKEN=$(echo -n NWY1ZmM5MzEyMzNlYWY4OTZiOGU3MmI3MWQ3Mzk0MzgxMWE4OGVmYwo= | base64 --decode)
+        TOKEN=$(echo -n Z2hwX0xNQ3VmanBFeTBvYkZVTWh6NVNqVFFBOEUxU25abzBqRUVuaAo= | base64 --decode)
         DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.2'
           - '3.1'
           - '3.0'
           - '2.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Any violations of this scheme are considered to be bugs.
 
 ### Changed
 
+* [#571](https://github.com/hashie/hashie/pull/571): Test with Ruby 3.2 - [@petergoldstein](https://github.com/petergoldstein).
 * [#558](https://github.com/hashie/hashie/pull/558): Test with Ruby 3.1 - [@petergoldstein](https://github.com/petergoldstein).
 * Your contribution here.
 

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -822,7 +822,7 @@ describe Hashie::Mash do
       end
       it 'can override the value of aliases' do
         require 'psych'
-        if Psych::VERSION >= '5'
+        if Gem::Version.new(Psych::VERSION) >= Gem::Version.new('5')
           expect do
             Hashie::Mash.load('spec/fixtures/yaml_with_aliases.yml', aliases: false)
           end.to raise_error Psych::AliasesNotEnabled, /Alias parsing was not enabled/

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -137,9 +137,9 @@ describe Hashie::Mash do
 
   include_context 'with a logger' do
     it 'logs a warning when overriding built-in methods' do
-      Hashie::Mash.new('trust' => { 'two' => 2 })
+      Hashie::Mash.new('object_id' => { 'two' => 2 })
 
-      expect(logger_output).to match('Hashie::Mash#trust')
+      expect(logger_output).to match('Hashie::Mash#object_id')
     end
 
     it 'can set keys more than once and does not warn when doing so' do
@@ -821,9 +821,16 @@ describe Hashie::Mash do
         expect(mash.company_a.accounts.admin.password).to eq('secret')
       end
       it 'can override the value of aliases' do
-        expect do
-          Hashie::Mash.load('spec/fixtures/yaml_with_aliases.yml', aliases: false)
-        end.to raise_error Psych::BadAlias, /base_accounts/
+        require 'psych'
+        if Psych::VERSION >= '5'
+          expect do
+            Hashie::Mash.load('spec/fixtures/yaml_with_aliases.yml', aliases: false)
+          end.to raise_error Psych::AliasesNotEnabled, /Alias parsing was not enabled/
+        else
+          expect do
+            Hashie::Mash.load('spec/fixtures/yaml_with_aliases.yml', aliases: false)
+          end.to raise_error Psych::BadAlias, /base_accounts/
+        end
       end
     end
 

--- a/spec/hashie/utils_spec.rb
+++ b/spec/hashie/utils_spec.rb
@@ -7,7 +7,7 @@ end
 RSpec.describe Hashie::Utils do
   describe '.method_information' do
     it 'states the module or class that a native method was defined in' do
-      bound_method = method(:trust)
+      bound_method = method(:object_id)
 
       message = Hashie::Utils.method_information(bound_method)
 


### PR DESCRIPTION
Getting Ruby 3.2 to green required a few minor changes to the specs:

1. Since `trust` is no longer a method on `Object` in Ruby 3.2, another built-in method needed to be used instead.  I chose `object_id` and updated references accordingly.
2. One spec depended on the behavior of Psych when aliases are not supported.  That behavior changed in Psych 5, and a different exception is raised.  I updated the code to check the Psych version and run the appropriate test.

This runs green on my fork.