### PR TITLE
Fix: integration tests in CI.

### DIFF
--- a/spec/integration/omniauth/Rakefile
+++ b/spec/integration/omniauth/Rakefile
@@ -4,8 +4,9 @@ namespace :perf do
   task :setup do
     require 'omniauth'
     require 'rack/test'
+    require 'securerandom'
     app = Rack::Builder.new do |b|
-      b.use Rack::Session::Cookie, secret: 'abc123'
+      b.use Rack::Session::Cookie, secret: SecureRandom.hex(64)
       b.use OmniAuth::Strategies::Developer
       b.run ->(_env) { [200, {}, ['Not Found']] }
     end.to_app

--- a/spec/integration/omniauth/app.rb
+++ b/spec/integration/omniauth/app.rb
@@ -1,8 +1,9 @@
 require 'sinatra'
 require 'omniauth'
+require 'securerandom'
 
 class MyApplication < Sinatra::Base
-  use Rack::Session::Cookie, secret: 'hashie integration tests'
+  use Rack::Session::Cookie, secret: SecureRandom.hex(64)
   use OmniAuth::Strategies::Developer
 
   get '/' do


### PR DESCRIPTION
```
 1) omniauth works
     Failure/Error: get '/'

     ArgumentError:
       invalid secret: 24, must be >=64
     # ./spec/integration/omniauth/integration_spec.rb:34:in `block (2 levels) in <top (required)>'
     # ./spec/integration/omniauth/integration_spec.rb:25:in `block (2 levels) in <top (required)>'
```

https://github.com/hashie/hashie/actions/runs/8597426729/job/23574774172

Rails secret min length has changed in a minor version?